### PR TITLE
bug-fix: Data Inconsistency (Required Graceful termination and waitgroups in pkg/controllers)

### DIFF
--- a/internal/cloudproviders/azure/vm.go
+++ b/internal/cloudproviders/azure/vm.go
@@ -672,7 +672,6 @@ func (obj *AzureProvider) CreateNetworkInterface(ctx context.Context, storage re
 		}
 	}()
 
-	// Wait for both goroutines to finish before returning
 	waitGroup.Wait()
 
 	log.Debug("Printing", "mainStateDocument", mainStateDocument)


### PR DESCRIPTION
# Tasks description

```[tasklist]
### Related Issues
- [ ] #257
``` 

# Solution

```[tasklist]
### Tasks
- [x] Implement `sync.WaitGroup` for coordinating goroutines in `CreateNetworkInterface` method.
``` 

<!--Add here-->

# Note to reviewers

<!--Add here-->

- [x] Ran Tests locally
- [x] Checked [Contribution's guidelines](https://kubesimplify.github.io/ksctl-docs/docs/contribution-guidelines/)
