### PR TITLE
feat: added the customdata or init script to azure and civo vms

### DIFF
--- a/internal/cloudproviders/civo/vm.go
+++ b/internal/cloudproviders/civo/vm.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/civo/civogo"
+	"github.com/ksctl/ksctl/pkg/helpers"
 	"github.com/ksctl/ksctl/pkg/resources"
 
 	"github.com/ksctl/ksctl/pkg/helpers/consts"
@@ -99,6 +100,12 @@ func (obj *CivoProvider) NewVM(storage resources.StorageFactory, index int) erro
 
 	networkID := mainStateDocument.CloudInfra.Civo.NetworkID
 
+	initScript, err := helpers.GenerateInitScriptForVM(name)
+	if err != nil {
+		return log.NewError(err.Error())
+	}
+	log.Debug("initscript", "script", initScript)
+
 	instanceConfig := &civogo.InstanceConfig{
 		Hostname:         name,
 		InitialUser:      mainStateDocument.CloudInfra.Civo.B.SSHUser,
@@ -109,7 +116,7 @@ func (obj *CivoProvider) NewVM(storage resources.StorageFactory, index int) erro
 		NetworkID:        networkID,
 		SSHKeyID:         mainStateDocument.CloudInfra.Civo.B.SSHID,
 		PublicIPRequired: publicIP,
-		// Script:           initializationScript,  // TODO: add the os updates and other non necessary things before we try to configure in kubernetes may be security fixes
+		Script:           initScript,
 	}
 
 	log.Debug("Printing", "instanceConfig", instanceConfig)

--- a/internal/k8sdistros/universal/kubernetes.go
+++ b/internal/k8sdistros/universal/kubernetes.go
@@ -36,6 +36,7 @@ func (this *Kubernetes) DeleteWorkerNodes(nodeName string) error {
 
 	kNodeName := ""
 	for _, node := range nodes.Items {
+		log.Debug("string compariazion", "nodeToDelete", nodeName, "kubernetesNodeName", node.Name)
 		if strings.HasPrefix(node.Name, nodeName) {
 			kNodeName = node.Name
 			break

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ksctl/ksctl/internal/storage/types"
 	"github.com/ksctl/ksctl/pkg/helpers"
@@ -372,6 +373,8 @@ func (ksctlControlCli *KsctlControllerClient) CreateHACluster(client *resources.
 	}
 
 	log.Warn("only cloud resources are having replay!")
+
+	time.Sleep(30 * time.Second) // hack to wait for all the cloud specific resources to be in consistent state
 	// Kubernetes controller
 	externalCNI, err := kubernetes.ConfigureCluster(client)
 	if err != nil {

--- a/pkg/helpers/state.go
+++ b/pkg/helpers/state.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"os"
 	"strings"
@@ -51,4 +52,15 @@ func GenRandomString(length int) (string, error) {
 	}
 
 	return string(ret), nil
+}
+
+func GenerateInitScriptForVM(resName string) (string, error) {
+
+	postfixStr, err := GenRandomString(5)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`#!/bin/bash
+sudo hostname %s-%s
+`, resName, postfixStr), nil
 }

--- a/test/e2e/args.go
+++ b/test/e2e/args.go
@@ -36,7 +36,12 @@ func GetReqPayload(l resources.LoggerFactory) (Operation, resources.Metadata) {
 		os.Exit(1)
 	}
 
-	payload.LogVerbosity = 0
+	verbosityLevel := 0
+	if os.Getenv("E2E_LOG_LEVEL") == "DEBUG" {
+		verbosityLevel = -1
+	}
+
+	payload.LogVerbosity = verbosityLevel
 	payload.LogWritter = os.Stdout
 
 	return Operation(*arg1), payload


### PR DESCRIPTION
# Tasks description
as the #277 has the issue with the aws povider having ip based hostname which also reflects in the `kubectl get nodes` so we can add a init script for changing the hostname

## Issues
### Related Issue(s)
- #302 
- #277


# Solution

### Sub-Tasks
- [x] do a run
- [x] check if the kuberneytes client working for scaledown with debug flag on!
- [x] Check on civo cloud
- [x] check on azure cloud

# Note to reviewers

- [x] Ran Tests locally
- [x] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
