### PR TITLE
Update the version for Kubernetes used by Jenkins to run tests on Civo to current lastest.

### DIFF
--- a/test/e2e/civo/create.json
+++ b/test/e2e/civo/create.json
@@ -1,6 +1,6 @@
 {
 	"cluster_name": "test-e2e-civo",
-	"kubernetes_version": "1.27.1",
+	"kubernetes_version": "1.28.7",
 	"region": "LON1",
 	"ha_cluster": false,
 	"cloud_provider": "civo",


### PR DESCRIPTION
# Tasks description

## Issues
### Completed Issue(s)
- #307

# Solution
Updated the version for Kubernetes to ``1.28.7-k3s1`` as described by the failure log.

### Sub-Tasks
- [x] Update the version used by Jenkins' Civo tests to latest


# Note to reviewers
- [x] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
