### PR TITLE
FIX PR-288 [Blocked]

### DIFF
--- a/internal/k8sdistros/k3s/controlplane.go
+++ b/internal/k8sdistros/k3s/controlplane.go
@@ -249,7 +249,7 @@ sudo ./control-setup.sh
 
 func scriptForK3sToken() string {
 	return `#!/bin/bash
-sudo cat /var/lib/rancher/k3s/server/token
+sudo cat /var/lib/rancher/k3s/server/token &
 `
 }
 


### PR DESCRIPTION
# Tasks description
This issue addresses a background process in the script. Adding '&' at the end of the command enables the script to run asynchronously in the background, allowing the execution to continue without waiting for it to complete. This change meets the requirement mentioned in the PR to prevent blocking scripts unless there's a data fetch from the server.

## Issues
### Completed Issue(s)
- #288

### Related Issue(s)
- #300


# Solution

### Sub-Tasks
- [ ] Modify scriptForK3sToken() function to run in the background

# Note to reviewers
- [ ] Ran Tests locally
- [ ] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
