### PR TITLE
enhancement: concurrency for k8s bootstrap process

### DIFF
--- a/internal/cloudproviders/civo/vm.go
+++ b/internal/cloudproviders/civo/vm.go
@@ -65,7 +65,6 @@ func (obj *CivoProvider) NewVM(storage resources.StorageFactory, index int) erro
 
 	log.Debug("Printing", "name", name, "indexNo", indexNo, "role", role, "vmType", vmtype)
 
-
 	err := obj.foundStateVM(storage, indexNo, true, role, name)
 	if err == nil {
 		return nil

--- a/internal/k8sdistros/datastore.go
+++ b/internal/k8sdistros/datastore.go
@@ -2,14 +2,20 @@ package k8sdistros
 
 import (
 	"fmt"
-	"github.com/ksctl/ksctl/pkg/helpers/consts"
-	"github.com/ksctl/ksctl/pkg/resources"
 	"strconv"
 	"strings"
+
+	"github.com/ksctl/ksctl/pkg/helpers"
+	"github.com/ksctl/ksctl/pkg/helpers/consts"
+	"github.com/ksctl/ksctl/pkg/resources"
 )
 
 func (p *PreBootstrap) ConfigureDataStore(no int, _ resources.StorageFactory) error {
+	p.mu.Lock()
 	idx := no
+	sshExecutor := helpers.NewSSHExecutor(mainStateDocument) //making sure that a new obj gets initialized for a every run thus eleminating possible problems with concurrency
+	p.mu.Unlock()
+
 	log.Print("configuring Datastore", "number", strconv.Itoa(idx))
 
 	err := sshExecutor.Flag(consts.UtilExecWithoutOutput).Script(
@@ -25,10 +31,6 @@ func (p *PreBootstrap) ConfigureDataStore(no int, _ resources.StorageFactory) er
 		return log.NewError(err.Error())
 	}
 
-	//err = storage.Write(mainStateDocument)
-	//if err != nil {
-	//	return log.NewError(err.Error())
-	//}
 	log.Success("configured DataStore", "number", strconv.Itoa(idx))
 
 	return nil

--- a/internal/k8sdistros/k3s/k3s_test.go
+++ b/internal/k8sdistros/k3s/k3s_test.go
@@ -3,9 +3,11 @@ package k3s
 import (
 	"context"
 	"fmt"
-	"github.com/ksctl/ksctl/pkg/logger"
 	"os"
+	"sync"
 	"testing"
+
+	"github.com/ksctl/ksctl/pkg/logger"
 
 	"github.com/ksctl/ksctl/internal/storage/types"
 
@@ -28,7 +30,6 @@ var (
 func NewClientHelper(x cloudControlRes.CloudResourceState, storage resources.StorageFactory, m resources.Metadata, state *types.StorageDocument) *K3s {
 
 	mainStateDocument = state
-	sshExecutor = helpers.NewSSHExecute()
 	mainStateDocument.K8sBootstrap = &types.KubernetesBootstrapState{}
 	var err error
 	mainStateDocument.K8sBootstrap.B.CACert, mainStateDocument.K8sBootstrap.B.EtcdCert, mainStateDocument.K8sBootstrap.B.EtcdKey, err = helpers.GenerateCerts(log, x.PrivateIPv4DataStores)
@@ -48,9 +49,7 @@ func NewClientHelper(x cloudControlRes.CloudResourceState, storage resources.Sto
 	mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer = x.PrivateIPv4LoadBalancer
 	mainStateDocument.K8sBootstrap.B.SSHInfo = x.SSHState
 
-	sshExecutor.PrivateKey(mainStateDocument.K8sBootstrap.B.SSHInfo.PrivateKey)
-	sshExecutor.Username(mainStateDocument.K8sBootstrap.B.SSHInfo.UserName)
-	return &K3s{}
+	return &K3s{mu: &sync.Mutex{}}
 }
 
 func TestMain(m *testing.M) {

--- a/internal/k8sdistros/kubeadm/kubeadm_test.go
+++ b/internal/k8sdistros/kubeadm/kubeadm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/ksctl/ksctl/pkg/logger"
@@ -29,7 +30,6 @@ var (
 func NewClientHelper(x cloudControlRes.CloudResourceState, storage resources.StorageFactory, m resources.Metadata, state *types.StorageDocument) *Kubeadm {
 
 	mainStateDocument = state
-	sshExecutor = helpers.NewSSHExecute()
 	mainStateDocument.K8sBootstrap = &types.KubernetesBootstrapState{}
 	var err error
 	mainStateDocument.K8sBootstrap.B.CACert, mainStateDocument.K8sBootstrap.B.EtcdCert, mainStateDocument.K8sBootstrap.B.EtcdKey, err = helpers.GenerateCerts(log, x.PrivateIPv4DataStores)
@@ -49,9 +49,7 @@ func NewClientHelper(x cloudControlRes.CloudResourceState, storage resources.Sto
 	mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer = x.PrivateIPv4LoadBalancer
 	mainStateDocument.K8sBootstrap.B.SSHInfo = x.SSHState
 
-	sshExecutor.PrivateKey(mainStateDocument.K8sBootstrap.B.SSHInfo.PrivateKey)
-	sshExecutor.Username(mainStateDocument.K8sBootstrap.B.SSHInfo.UserName)
-	return &Kubeadm{}
+	return &Kubeadm{mu: &sync.Mutex{}}
 }
 
 func TestMain(m *testing.M) {

--- a/internal/k8sdistros/kubeadm/workerplane.go
+++ b/internal/k8sdistros/kubeadm/workerplane.go
@@ -2,12 +2,18 @@ package kubeadm
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/ksctl/ksctl/pkg/helpers"
 	"github.com/ksctl/ksctl/pkg/helpers/consts"
 	"github.com/ksctl/ksctl/pkg/resources"
-	"strconv"
 )
 
-func (p *Kubeadm) JoinWorkerplane(idx int, storage resources.StorageFactory) error {
+func (p *Kubeadm) JoinWorkerplane(noOfWP int, storage resources.StorageFactory) error {
+	p.mu.Lock()
+	idx := noOfWP
+	sshExecutor := helpers.NewSSHExecutor(mainStateDocument) //making sure that a new obj gets initialized for a every run thus eleminating possible problems with concurrency
+	p.mu.Unlock()
 
 	log.Print("configuring Workerplane", "number", strconv.Itoa(idx))
 

--- a/internal/k8sdistros/loadbalancer.go
+++ b/internal/k8sdistros/loadbalancer.go
@@ -2,6 +2,8 @@ package k8sdistros
 
 import (
 	"fmt"
+
+	"github.com/ksctl/ksctl/pkg/helpers"
 	"github.com/ksctl/ksctl/pkg/helpers/consts"
 
 	"github.com/ksctl/ksctl/pkg/resources"
@@ -9,6 +11,9 @@ import (
 
 func (p *PreBootstrap) ConfigureLoadbalancer(_ resources.StorageFactory) error {
 	log.Print("configuring Loadbalancer")
+	p.mu.Lock()
+	sshExecutor := helpers.NewSSHExecutor(mainStateDocument) //making sure that a new obj gets initialized for a every run thus eleminating possible problems with concurrency
+	p.mu.Unlock()
 
 	var controlPlaneIPs = make([]string, len(mainStateDocument.K8sBootstrap.B.PublicIPs.ControlPlanes))
 

--- a/internal/k8sdistros/types.go
+++ b/internal/k8sdistros/types.go
@@ -1,4 +1,7 @@
 package k8sdistros
 
+import "sync"
+
 type PreBootstrap struct {
+	mu *sync.Mutex
 }

--- a/test/e2e/civo/create-ha.json
+++ b/test/e2e/civo/create-ha.json
@@ -6,7 +6,7 @@
 	"cloud_provider": "civo",
 	"kubernetes_distro": "k3s",
 	"storage_type": "local",
-	"node_type_workerplane": "g3.large",
+	"node_type_workerplane": "g3.medium",
 	"node_type_controlplane": "g3.small",
 	"node_type_datastore": "g3.small",
 	"node_type_loadbalancer": "g3.small",

--- a/test/e2e/civo/scaleup-ha.json
+++ b/test/e2e/civo/scaleup-ha.json
@@ -6,6 +6,6 @@
 	"cloud_provider": "civo",
 	"kubernetes_distro": "k3s",
 	"storage_type": "local",
-	"node_type_workerplane": "g3.large",
+	"node_type_workerplane": "g3.medium",
 	"desired_no_of_workerplane_nodes": 1
 }


### PR DESCRIPTION
# Tasks description
It adds concurrency for kubeadm and k3s for much faster creation time

## Issues
### Completed Issue(s)
- Partially completes #288

### Related Issue(s)
- #314 


# Solution

use of `sshExecutor` which is noot global var inside a given pkg instead a new instance of the interface is created everytime a go routine for ssh into a vm is created

> [!NOTE]
> after considering the overhead its not much of a problem as the go-routines spining up is dependent on the users wish and the object is not used after the goroutine execution is completed so its garbage collected

### Sub-Tasks
- [x] Enable concurrency
- [x] Modify the unit tests


# Note to reviewers

- [x] Ran Tests locally
- [x] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
