### PR TITLE
[Enhancement]: FirewallRules for all cloud providers self-managed ha clusters

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -73,6 +73,12 @@ jobs:
          go test -race -coverprofile=../../../coverage-azure.out -covermode=atomic -v
          cd ../../..
 
+    - name: Run coverage (AWS)
+      working-directory: internal/cloudproviders/aws
+      run: |
+         go test -race -coverprofile=../../../coverage-aws.out -covermode=atomic -v
+         cd ../../..
+
     - name: Run coverage (LOCAL)
       working-directory: internal/cloudproviders/local
       run: |

--- a/.github/workflows/testingAws.yml
+++ b/.github/workflows/testingAws.yml
@@ -1,0 +1,91 @@
+name: Regression Test Aws
+on:
+  push:
+    paths:
+      - 'internal/cloudproviders/aws/**'
+      - 'internal/storage/**'
+      - 'pkg/helpers/**'
+      - 'pkg/logger/**'
+      - 'go.mod'
+      - 'go.sum'
+    branches: [ main ]
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+    paths:
+    - 'internal/cloudproviders/aws/**'
+    - 'internal/storage/**'
+    - 'pkg/helpers/**'
+    - 'pkg/logger/**'
+    - 'go.mod'
+    - 'go.sum'
+
+jobs:
+  unit-test:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      (
+        github.event.label.name == 'tests/enable' ||
+        contains(github.event.pull_request.labels.*.name, 'tests/enable')
+      ) &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'pr/lgtm') != true ||
+        github.event.label.name != 'pr/lgtm'
+      )
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.0
+
+      - name: Testing
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          make unit_test_aws
+
+      - name: Testing
+        if: ${{ matrix.os == 'windows-latest' }}
+        working-directory: scripts
+        run: .\test-aws.ps1
+
+  mock-integration-test:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    if: |
+      (
+        github.event.label.name == 'tests/enable' ||
+        contains(github.event.pull_request.labels.*.name, 'tests/enable')
+      ) &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'pr/lgtm') ||
+        github.event.label.name == 'pr/lgtm'
+      )
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.0
+
+      - name: integration testing
+        working-directory: test
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          # go test -bench=BenchmarkAwsTestingManaged -benchtime=1x -cover -v
+          go test -bench=BenchmarkAwsTestingHA -benchtime=1x -cover -v
+
+      - name: integration testing
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          # make mock_aws_managed
+          make mock_aws_ha
+

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ unit_test_azure: golang-test ## azure unit test case
 	cd scripts/ && \
 		/bin/bash test-azure.sh $(GO_TEST_COLOR)
 
+.PHONY: unit_test_aws
+unit_test_aws: golang-test ## aws unit test case
+	@echo "Unit Tests"
+	cd scripts/ && \
+		/bin/bash test-aws.sh $(GO_TEST_COLOR)
+
 .PHONY: unit_test_k3s
 unit_test_k3s: golang-test ## k3s unit test case
 	@echo "Unit Tests"
@@ -150,6 +156,12 @@ mock_azure_managed: golang-test ## Azure managed mock test
 mock_azure_ha: golang-test ## Azure HA mock test
 	cd test/ && \
  		GOTEST_PALETTE="red,yellow,green" $(GO_TEST_COLOR) -bench=BenchmarkAzureTestingHA -benchtime=1x -cover -v
+
+.PHONY: mock-aws-ha
+mock_aws_ha: golang-test ## Aws HA mock test
+	cd test/ && \
+ 		GOTEST_PALETTE="red,yellow,green" $(GO_TEST_COLOR) -bench=BenchmarkAwsTestingHA -benchtime=1x -cover -v
+
 
 .PHONY: mock-local-managed
 mock_local_managed: golang-test ## Local managed mock test

--- a/internal/cloudproviders/aws/awsgo.go
+++ b/internal/cloudproviders/aws/awsgo.go
@@ -602,11 +602,11 @@ func (awsclient *AwsGoClient) setRequiredENVVAR(storage resources.StorageFactory
 		return err
 	}
 
-	err = os.Setenv("AWS_ACCESS_KEY_ID", credentials.Aws.AcessKeyID)
+	err = os.Setenv("AWS_ACCESS_KEY_ID", credentials.Aws.AccessKeyId)
 	if err != nil {
 		return err
 	}
-	err = os.Setenv("AWS_SECRET_ACCESS_KEY", credentials.Aws.AcessKeySecret)
+	err = os.Setenv("AWS_SECRET_ACCESS_KEY", credentials.Aws.SecretAccessKey)
 	if err != nil {
 		return err
 	}

--- a/internal/cloudproviders/aws/firewall.go
+++ b/internal/cloudproviders/aws/firewall.go
@@ -127,7 +127,7 @@ func (obj *AwsProvider) CreateSecurityGroup(name string, role consts.KsctlRole) 
 		return "", err
 	}
 
-	log.Success("Created SecurityGroup", "name", string(role+"securitygroup"))
+	log.Success("Created SecurityGroup", "name", name)
 
 	return *SecurityGroup.GroupId, nil
 }

--- a/internal/cloudproviders/aws/firewall.go
+++ b/internal/cloudproviders/aws/firewall.go
@@ -122,6 +122,7 @@ func (obj *AwsProvider) CreateSecurityGroup(Role consts.KsctlRole) (string, erro
 	return *SecurityGroup.GroupId, nil
 }
 
+// Anchor for next steps
 func (obj *AwsProvider) createSecurityGroupRules(role consts.KsctlRole, SecurityGroup *ec2.CreateSecurityGroupOutput) (err error) {
 	var ip_protocol string
 	var cidr_ip string

--- a/internal/cloudproviders/aws/firewall.go
+++ b/internal/cloudproviders/aws/firewall.go
@@ -2,11 +2,14 @@ package aws
 
 import (
 	"context"
+	"strconv"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/ksctl/ksctl/pkg/helpers"
 	"github.com/ksctl/ksctl/pkg/helpers/consts"
 	"github.com/ksctl/ksctl/pkg/resources"
 )
@@ -109,12 +112,17 @@ func (obj *AwsProvider) CreateSecurityGroup(Role consts.KsctlRole) (string, erro
 		}
 	}
 
+	kubernetesDistro := mainStateDocument.CloudInfra.Aws.B.KubernetesDistro
+	netCidr := mainStateDocument.CloudInfra.Aws.VpcCidr
+
 	SecurityGroup, err := obj.client.BeginCreateSecurityGroup(context.Background(), SecurityGroupInput)
 	if err != nil {
 		return "", err
 	}
 
-	err = obj.createSecurityGroupRules(Role, SecurityGroup)
+	err = obj.createSecurityGroupRules(
+		consts.KsctlKubernetes(kubernetesDistro),
+		netCidr, Role, SecurityGroup)
 	if err != nil {
 		return "", err
 	}
@@ -122,53 +130,151 @@ func (obj *AwsProvider) CreateSecurityGroup(Role consts.KsctlRole) (string, erro
 	return *SecurityGroup.GroupId, nil
 }
 
-// Anchor for next steps
-func (obj *AwsProvider) createSecurityGroupRules(role consts.KsctlRole, SecurityGroup *ec2.CreateSecurityGroupOutput) (err error) {
-	var ip_protocol string
-	var cidr_ip string
-	var from_port int32
-	var to_port int32
+func (obj *AwsProvider) createSecurityGroupRules(
+	bootstrap consts.KsctlKubernetes,
+	netCidr string,
+	role consts.KsctlRole,
+	SecurityGroup *ec2.CreateSecurityGroupOutput,
+) (err error) {
 
-	ip_protocol = "-1"
-	cidr_ip = "0.0.0.0/0"
-	from_port = 0
-	to_port = 65535
+	var ingressrules ec2.AuthorizeSecurityGroupIngressInput
+	var egressrules ec2.AuthorizeSecurityGroupEgressInput
 
 	switch role {
 	case consts.RoleLb:
 		mainStateDocument.CloudInfra.Aws.InfoLoadBalancer.NetworkSecurityGroup = *SecurityGroup.GroupId
+		ingressrules, egressrules = firewallRuleLoadBalancer(SecurityGroup.GroupId)
+
 	case consts.RoleCp:
 		mainStateDocument.CloudInfra.Aws.InfoControlPlanes.NetworkSecurityGroup = *SecurityGroup.GroupId
+		ingressrules, egressrules = firewallRuleControlPlane(
+			SecurityGroup.GroupId,
+			netCidr,
+			bootstrap,
+		)
+
 	case consts.RoleWp:
 		mainStateDocument.CloudInfra.Aws.InfoWorkerPlanes.NetworkSecurityGroup = *SecurityGroup.GroupId
+		ingressrules, egressrules = firewallRuleWorkerPlane(
+			SecurityGroup.GroupId,
+			netCidr,
+			bootstrap,
+		)
+
 	case consts.RoleDs:
 		mainStateDocument.CloudInfra.Aws.InfoDatabase.NetworkSecurityGroup = *SecurityGroup.GroupId
+		ingressrules, egressrules = firewallRuleDataStore(
+			SecurityGroup.GroupId,
+			netCidr,
+		)
+
 	default:
 		return log.NewError("Error creating security group", "error", "invalid role")
-	}
-	ingressrules := ec2.AuthorizeSecurityGroupIngressInput{
-		GroupId:    SecurityGroup.GroupId,
-		IpProtocol: aws.String(ip_protocol),
-		CidrIp:     aws.String(cidr_ip),
 	}
 
 	if err := obj.client.AuthorizeSecurityGroupIngress(context.Background(), ingressrules); err != nil {
 		return err
 	}
 
-	egressrules := ec2.AuthorizeSecurityGroupEgressInput{
-		GroupId: SecurityGroup.GroupId,
-		IpPermissions: []types.IpPermission{
-			{
-				IpProtocol: aws.String(ip_protocol),
-				FromPort:   aws.Int32(from_port),
-				ToPort:     aws.Int32(to_port),
-			},
-		},
-	}
-
 	if err := obj.client.AuthorizeSecurityGroupEgress(context.Background(), egressrules); err != nil {
 		return err
 	}
 	return nil
+}
+
+func convertToProviderSpecific(_rules []helpers.FirewallRule, SgId *string) (ec2.AuthorizeSecurityGroupIngressInput, ec2.AuthorizeSecurityGroupEgressInput) {
+
+	ingressRules := []types.IpPermission{}
+	egressRules := []types.IpPermission{}
+
+	for _, _r := range _rules {
+
+		var protocol string
+
+		switch _r.Protocol {
+		case consts.FirewallActionTCP:
+			protocol = "tcp"
+		case consts.FirewallActionUDP:
+			protocol = "udp"
+		default:
+			protocol = "tcp"
+		}
+
+		_startPort, _ := strconv.Atoi(_r.StartPort)
+		_endPort, _ := strconv.Atoi(_r.EndPort)
+
+		v := types.IpPermission{
+			FromPort:   to.Ptr[int32](int32(_startPort)),
+			ToPort:     to.Ptr[int32](int32(_endPort)),
+			IpProtocol: to.Ptr[string](protocol),
+			IpRanges: []types.IpRange{
+				{
+					CidrIp:      to.Ptr[string](_r.Cidr),
+					Description: to.Ptr[string](_r.Description),
+				},
+			},
+		}
+
+		switch _r.Direction {
+		case consts.FirewallActionIngress:
+			ingressRules = append(ingressRules, v)
+
+		case consts.FirewallActionEgress:
+			egressRules = append(egressRules, v)
+		}
+	}
+
+	return ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       SgId,
+			IpPermissions: ingressRules,
+		}, ec2.AuthorizeSecurityGroupEgressInput{
+			GroupId:       SgId,
+			IpPermissions: egressRules,
+		}
+}
+
+func firewallRuleControlPlane(sgid *string,
+	internalNetCidr string,
+	bootstrap consts.KsctlKubernetes,
+) (ec2.AuthorizeSecurityGroupIngressInput,
+	ec2.AuthorizeSecurityGroupEgressInput) {
+
+	return convertToProviderSpecific(
+		helpers.FirewallForControlplane_BASE(internalNetCidr, bootstrap),
+		sgid,
+	)
+}
+
+func firewallRuleWorkerPlane(
+	sgid *string,
+	internalNetCidr string,
+	bootstrap consts.KsctlKubernetes,
+) (ec2.AuthorizeSecurityGroupIngressInput,
+	ec2.AuthorizeSecurityGroupEgressInput) {
+
+	return convertToProviderSpecific(
+		helpers.FirewallForWorkerplane_BASE(internalNetCidr, bootstrap),
+		sgid,
+	)
+}
+
+func firewallRuleLoadBalancer(
+	sgid *string,
+) (ec2.AuthorizeSecurityGroupIngressInput,
+	ec2.AuthorizeSecurityGroupEgressInput) {
+	return convertToProviderSpecific(
+		helpers.FirewallForLoadBalancer_BASE(),
+		sgid,
+	)
+}
+
+func firewallRuleDataStore(
+	sgid *string,
+	internalNetCidr string,
+) (ec2.AuthorizeSecurityGroupIngressInput,
+	ec2.AuthorizeSecurityGroupEgressInput) {
+	return convertToProviderSpecific(
+		helpers.FirewallForDataStore_BASE(internalNetCidr),
+		sgid,
+	)
 }

--- a/internal/cloudproviders/aws/firewall.go
+++ b/internal/cloudproviders/aws/firewall.go
@@ -226,18 +226,6 @@ func convertToProviderSpecific(_rules []helpers.FirewallRule, SgId *string) (ec2
 		}
 	}
 
-	// FIXME: small hack for aws for it to work nodePort
-	ingressRules = append(ingressRules, types.IpPermission{
-		FromPort:   to.Ptr[int32](int32(-1)),
-		ToPort:     to.Ptr[int32](int32(-1)),
-		IpProtocol: to.Ptr[string]("-1"),
-		IpRanges: []types.IpRange{
-			{
-				CidrIp: to.Ptr[string](mainStateDocument.CloudInfra.Aws.VpcCidr),
-			},
-		},
-	})
-
 	return ec2.AuthorizeSecurityGroupIngressInput{
 			GroupId:       SgId,
 			IpPermissions: ingressRules,

--- a/internal/cloudproviders/aws/firewall.go
+++ b/internal/cloudproviders/aws/firewall.go
@@ -226,6 +226,18 @@ func convertToProviderSpecific(_rules []helpers.FirewallRule, SgId *string) (ec2
 		}
 	}
 
+	// FIXME: small hack for aws for it to work nodePort
+	ingressRules = append(ingressRules, types.IpPermission{
+		FromPort:   to.Ptr[int32](int32(-1)),
+		ToPort:     to.Ptr[int32](int32(-1)),
+		IpProtocol: to.Ptr[string]("-1"),
+		IpRanges: []types.IpRange{
+			{
+				CidrIp: to.Ptr[string](mainStateDocument.CloudInfra.Aws.VpcCidr),
+			},
+		},
+	})
+
 	return ec2.AuthorizeSecurityGroupIngressInput{
 			GroupId:       SgId,
 			IpPermissions: ingressRules,

--- a/internal/cloudproviders/aws/helper.go
+++ b/internal/cloudproviders/aws/helper.go
@@ -27,8 +27,8 @@ func GetInputCredential(storage resources.StorageFactory, meta resources.Metadat
 	apiStore := &types.CredentialsDocument{
 		InfraProvider: consts.CloudAws,
 		Aws: &types.CredentialsAws{
-			AcessKeyID:     acesskey,
-			AcessKeySecret: acesskeysecret,
+			AccessKeyId:     acesskey,
+			SecretAccessKey: acesskeysecret,
 		},
 	}
 

--- a/internal/cloudproviders/aws/network.go
+++ b/internal/cloudproviders/aws/network.go
@@ -97,6 +97,7 @@ func (obj *AwsProvider) NewNetwork(storage resources.StorageFactory) error {
 				},
 			},
 		}
+		mainStateDocument.CloudInfra.Aws.VpcCidr = "172.31.0.0/16"
 
 		log.Debug("Printing", "virtualprivatecloud", vpcclient)
 

--- a/internal/cloudproviders/aws/vm.go
+++ b/internal/cloudproviders/aws/vm.go
@@ -429,7 +429,7 @@ func (obj *AwsProvider) DeleteNetworkInterface(ctx context.Context, storage reso
 func fetchgroupid(role consts.KsctlRole) (string, error) {
 	switch role {
 	case consts.RoleCp:
-		return mainStateDocument.CloudInfra.Aws.InfoWorkerPlanes.NetworkSecurityGroup, nil
+		return mainStateDocument.CloudInfra.Aws.InfoControlPlanes.NetworkSecurityGroup, nil
 	case consts.RoleWp:
 		return mainStateDocument.CloudInfra.Aws.InfoWorkerPlanes.NetworkSecurityGroup, nil
 	case consts.RoleLb:

--- a/internal/cloudproviders/azure/firewall.go
+++ b/internal/cloudproviders/azure/firewall.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"fmt"
+
 	"github.com/ksctl/ksctl/pkg/helpers"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"

--- a/internal/cloudproviders/azure/firewall.go
+++ b/internal/cloudproviders/azure/firewall.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"fmt"
+	"github.com/ksctl/ksctl/pkg/helpers"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -92,17 +93,19 @@ func (obj *AzureProvider) NewFirewall(storage resources.StorageFactory) error {
 		log.Success("skipped firewall already created", "name", nsg)
 		return nil
 	}
+	netCidr := mainStateDocument.CloudInfra.Azure.NetCidr
+	kubernetesDistro := consts.KsctlKubernetes(mainStateDocument.CloudInfra.Azure.B.KubernetesDistro)
 
 	var securityRules []*armnetwork.SecurityRule
 	switch role {
 	case consts.RoleCp:
-		securityRules = firewallRuleControlPlane()
+		securityRules = firewallRuleControlPlane(netCidr, kubernetesDistro)
 	case consts.RoleWp:
-		securityRules = firewallRuleWorkerPlane()
+		securityRules = firewallRuleWorkerPlane(netCidr, kubernetesDistro)
 	case consts.RoleLb:
 		securityRules = firewallRuleLoadBalancer()
 	case consts.RoleDs:
-		securityRules = firewallRuleDataStore()
+		securityRules = firewallRuleDataStore(netCidr)
 	default:
 		return log.NewError("invalid role")
 	}
@@ -162,142 +165,98 @@ func (obj *AzureProvider) NewFirewall(storage resources.StorageFactory) error {
 	return nil
 }
 
-// FIXME: add fine-grained rules
-func firewallRuleControlPlane() (securityRules []*armnetwork.SecurityRule) {
-	securityRules = []*armnetwork.SecurityRule{
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_6443"),
+func convertToProviderSpecific(_rules []helpers.FirewallRule) []*armnetwork.SecurityRule {
+	rules := []*armnetwork.SecurityRule{}
+	priority := int32(100)
+	for _, _r := range _rules {
+		priority++
+
+		var protocol armnetwork.SecurityRuleProtocol
+		var action armnetwork.SecurityRuleAccess
+		var direction armnetwork.SecurityRuleDirection
+		var portRange string
+		var srcCidr, destCidr string
+
+		switch _r.Action {
+		case consts.FirewallActionAllow:
+			action = armnetwork.SecurityRuleAccessAllow
+		case consts.FirewallActionDeny:
+			action = armnetwork.SecurityRuleAccessDeny
+		default:
+			action = armnetwork.SecurityRuleAccessAllow
+		}
+
+		switch _r.Protocol {
+		case consts.FirewallActionTCP:
+			protocol = armnetwork.SecurityRuleProtocolTCP
+		case consts.FirewallActionUDP:
+			protocol = armnetwork.SecurityRuleProtocolUDP
+		default:
+			protocol = armnetwork.SecurityRuleProtocolTCP
+		}
+
+		switch _r.Direction {
+		case consts.FirewallActionIngress:
+			direction = armnetwork.SecurityRuleDirectionInbound
+			srcCidr = _r.Cidr
+			destCidr = mainStateDocument.CloudInfra.Azure.NetCidr
+		case consts.FirewallActionEgress:
+			direction = armnetwork.SecurityRuleDirectionOutbound
+			destCidr = _r.Cidr
+			srcCidr = mainStateDocument.CloudInfra.Azure.NetCidr
+		default:
+			direction = armnetwork.SecurityRuleDirectionInbound
+		}
+
+		if _r.StartPort == _r.EndPort {
+			portRange = _r.StartPort
+		} else {
+			portRange = _r.StartPort + "-" + _r.EndPort
+			if portRange == "1-65535" {
+				portRange = "*"
+			}
+		}
+
+		rules = append(rules, &armnetwork.SecurityRule{
+			Name: to.Ptr(_r.Name),
 			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
+				SourceAddressPrefix:      to.Ptr(srcCidr),
 				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](100),
-				Description:              to.Ptr("sample network security group inbound port 6443"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+				DestinationAddressPrefix: to.Ptr(destCidr),
+				DestinationPortRange:     to.Ptr(portRange),
+				Protocol:                 to.Ptr(protocol),
+				Access:                   to.Ptr(action),
+				Priority:                 to.Ptr[int32](priority),
+				Description:              to.Ptr(_r.Description),
+				Direction:                to.Ptr(direction),
 			},
-		},
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_30_to_35k"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](101),
-				Description:              to.Ptr("sample network security group inbound port 30000-35000"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
-			},
-		},
+		})
 	}
 
-	return
+	return rules
+
 }
 
-// FIXME: add fine-grained rules
-func firewallRuleWorkerPlane() (securityRules []*armnetwork.SecurityRule) {
-	securityRules = []*armnetwork.SecurityRule{
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_6443"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](100),
-				Description:              to.Ptr("sample network security group inbound port 6443"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
-			},
-		},
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_30_to_35k"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](101),
-				Description:              to.Ptr("sample network security group inbound port 30000-35000"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
-			},
-		},
-	}
-	return
+func firewallRuleControlPlane(internalNetCidr string, bootstrap consts.KsctlKubernetes) (securityRules []*armnetwork.SecurityRule) {
+	return convertToProviderSpecific(
+		helpers.FirewallForControlplane_BASE(internalNetCidr, bootstrap),
+	)
 }
 
-// FIXME: add fine-grained rules
+func firewallRuleWorkerPlane(internalNetCidr string, bootstrap consts.KsctlKubernetes) (securityRules []*armnetwork.SecurityRule) {
+	return convertToProviderSpecific(
+		helpers.FirewallForWorkerplane_BASE(internalNetCidr, bootstrap),
+	)
+}
+
 func firewallRuleLoadBalancer() (securityRules []*armnetwork.SecurityRule) {
-	securityRules = []*armnetwork.SecurityRule{
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_6443"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](100),
-				Description:              to.Ptr("sample network security group inbound port 6443"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
-			},
-		}, &armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_30_to_35k"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](101),
-				Description:              to.Ptr("sample network security group inbound port 30000-35000"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
-			},
-		},
-	}
-	return
+	return convertToProviderSpecific(
+		helpers.FirewallForLoadBalancer_BASE(),
+	)
 }
 
-// FIXME: add fine-grained rules
-func firewallRuleDataStore() (securityRules []*armnetwork.SecurityRule) {
-	securityRules = []*armnetwork.SecurityRule{
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_6443"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](100),
-				Description:              to.Ptr("sample network security group inbound port 6443"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
-			},
-		},
-		&armnetwork.SecurityRule{
-			Name: to.Ptr("sample_inbound_30_to_35k"),
-			Properties: &armnetwork.SecurityRulePropertiesFormat{
-				SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
-				SourcePortRange:          to.Ptr("*"),
-				DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
-				DestinationPortRange:     to.Ptr("*"),
-				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
-				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 to.Ptr[int32](101),
-				Description:              to.Ptr("sample network security group inbound port 30000-35000"),
-				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
-			},
-		},
-	}
-	return
+func firewallRuleDataStore(internalNetCidr string) (securityRules []*armnetwork.SecurityRule) {
+	return convertToProviderSpecific(
+		helpers.FirewallForDataStore_BASE(internalNetCidr),
+	)
 }

--- a/internal/cloudproviders/azure/network.go
+++ b/internal/cloudproviders/azure/network.go
@@ -90,7 +90,7 @@ func (obj *AzureProvider) CreateVirtualNetwork(ctx context.Context, storage reso
 	if err != nil {
 		return err
 	}
-
+	mainStateDocument.CloudInfra.Azure.VirtualNetworkID = *resp.ID
 	if err := storage.Write(mainStateDocument); err != nil {
 		return err
 	}

--- a/internal/cloudproviders/azure/network.go
+++ b/internal/cloudproviders/azure/network.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"context"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -72,6 +71,7 @@ func (obj *AzureProvider) CreateVirtualNetwork(ctx context.Context, storage reso
 			},
 		},
 	}
+	mainStateDocument.CloudInfra.Azure.NetCidr = "10.1.0.0/16"
 
 	log.Debug("Printing", "virtualNetworkConfig", parameters)
 
@@ -91,7 +91,6 @@ func (obj *AzureProvider) CreateVirtualNetwork(ctx context.Context, storage reso
 		return err
 	}
 
-	mainStateDocument.CloudInfra.Azure.VirtualNetworkID = *resp.ID
 	if err := storage.Write(mainStateDocument); err != nil {
 		return err
 	}

--- a/internal/cloudproviders/civo/civo_test.go
+++ b/internal/cloudproviders/civo/civo_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/civo/civogo"
 	"github.com/ksctl/ksctl/pkg/resources/controllers/cloud"
 
 	"github.com/ksctl/ksctl/internal/storage/types"
@@ -361,29 +362,50 @@ func TestCni(t *testing.T) {
 }
 
 func TestFirewallRules(t *testing.T) {
-	t.Run("Controlplane fw rules", func(t *testing.T) {
-		if firewallRuleControlPlane() != nil {
-			t.Fatalf("missmatch firewall rule")
-		}
-	})
+	_rules := []helpers.FirewallRule{
+		{
+			Description: "nice",
+			Name:        "hello",
+			Protocol:    consts.FirewallActionUDP,
+			Direction:   consts.FirewallActionEgress,
+			Action:      consts.FirewallActionDeny,
+			Cidr:        "1.1.1./0",
+			StartPort:   "34",
+			EndPort:     "13445",
+		},
+		{
+			Description: "324nice",
+			Name:        "he23llo",
+			Protocol:    consts.FirewallActionTCP,
+			Direction:   consts.FirewallActionIngress,
+			Cidr:        "1.1.12./0",
+			StartPort:   "1",
+			EndPort:     "65000",
+		},
+	}
+	expect := []civogo.FirewallRule{
+		{
+			Direction: "egress",
+			Action:    "deny",
+			Protocol:  "udp",
 
-	t.Run("Workerplane fw rules", func(t *testing.T) {
-		if firewallRuleWorkerPlane() != nil {
-			t.Fatalf("missmatch firewall rule")
-		}
-	})
+			Label:     _rules[0].Description,
+			Cidr:      []string{_rules[0].Cidr},
+			StartPort: _rules[0].StartPort,
+			EndPort:   _rules[0].EndPort,
+		},
+		{
+			Direction: "ingress",
+			Action:    "allow",
+			Protocol:  "tcp",
 
-	t.Run("Loadbalancer fw rules", func(t *testing.T) {
-		if firewallRuleLoadBalancer() != nil {
-			t.Fatalf("missmatch firewall rule")
-		}
-	})
-
-	t.Run("Datastore fw rules", func(t *testing.T) {
-		if firewallRuleDataStore() != nil {
-			t.Fatalf("missmatch firewall rule")
-		}
-	})
+			Label:     _rules[1].Description,
+			Cidr:      []string{_rules[1].Cidr},
+			StartPort: _rules[1].StartPort,
+			EndPort:   _rules[1].EndPort,
+		},
+	}
+	assert.DeepEqual(t, expect, convertToProviderSpecific(_rules))
 }
 
 func TestDeleteVarCluster(t *testing.T) {

--- a/internal/cloudproviders/civo/firewall.go
+++ b/internal/cloudproviders/civo/firewall.go
@@ -95,6 +95,7 @@ func (obj *CivoProvider) NewFirewall(storage resources.StorageFactory) error {
 	}
 
 	netCidr := mainStateDocument.CloudInfra.Civo.NetworkCIDR
+	kubernetesDistro := consts.KsctlKubernetes(mainStateDocument.CloudInfra.Civo.B.KubernetesDistro)
 
 	switch role {
 	case consts.RoleCp:

--- a/internal/cloudproviders/civo/network.go
+++ b/internal/cloudproviders/civo/network.go
@@ -24,7 +24,15 @@ func (obj *CivoProvider) NewNetwork(storage resources.StorageFactory) error {
 		return log.NewError(err.Error())
 	}
 	mainStateDocument.CloudInfra.Civo.NetworkID = res.ID
+
+	net, err := obj.client.GetNetwork(res.ID)
+	if err != nil {
+		return log.NewError(err.Error())
+	}
+	mainStateDocument.CloudInfra.Civo.NetworkCIDR = net.CIDR
+
 	log.Debug("Printing", "networkID", res.ID)
+	log.Debug("Printing", "networkCIDR", net.CIDR)
 	log.Success("Created network", "name", name)
 
 	if err := storage.Write(mainStateDocument); err != nil {

--- a/internal/k8sdistros/distro_test.go
+++ b/internal/k8sdistros/distro_test.go
@@ -145,7 +145,7 @@ sudo systemctl start etcd
 }
 
 func TestScriptsLoadbalancer(t *testing.T) {
-	array := []string{"127.0.0.1:6443", "127.0.0.2:6443", "127.0.0.3:6443"}
+	array := []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"}
 
 	testHelper.HelperTestTemplate(
 		t,
@@ -155,8 +155,10 @@ func TestScriptsLoadbalancer(t *testing.T) {
 				CanRetry:   true,
 				MaxRetries: 9,
 				ShellScript: `
-sudo apt update -y
-sudo apt install haproxy -y
+sudo DEBIAN_FRONTEND=noninteractive apt update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends software-properties-common -y
+sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:vbernat/haproxy-2.8 -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install haproxy=2.8.\* -y
 `,
 				ScriptExecutor: consts.LinuxBash,
 			},
@@ -199,8 +201,9 @@ sudo mv haproxy.cfg /etc/haproxy/haproxy.cfg
 `,
 			},
 			{
-				Name:           "create haproxy configuration",
-				CanRetry:       false,
+				Name:           "restarting haproxy",
+				CanRetry:       true,
+				MaxRetries:     3,
 				ScriptExecutor: consts.LinuxBash,
 				ShellScript: `
 sudo systemctl restart haproxy

--- a/internal/k8sdistros/k3s/controlplane.go
+++ b/internal/k8sdistros/k3s/controlplane.go
@@ -167,7 +167,8 @@ sudo mv -v ca.pem etcd.pem etcd-key.pem /var/lib/etcd
 	}
 }
 
-func scriptCP_1WithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string, privIplb, pubIPlb string) resources.ScriptCollection {
+func scriptCP_1WithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string,
+	pubIPlb, privIplb string) resources.ScriptCollection {
 
 	collection := helpers.NewScriptCollection()
 
@@ -206,7 +207,8 @@ sudo ./control-setup.sh &>> ksctl.log
 	return collection
 }
 
-func scriptCP_1(ca, etcd, key, ver string, privateEtcdIps []string, pubIPlb, privateIPLb string) resources.ScriptCollection {
+func scriptCP_1(ca, etcd, key, ver string, privateEtcdIps []string, pubIPlb,
+	privateIPLb string) resources.ScriptCollection {
 
 	collection := helpers.NewScriptCollection()
 
@@ -256,7 +258,8 @@ sudo cat /var/lib/rancher/k3s/server/token
 	return collection
 }
 
-func scriptCP_N(ca, etcd, key, ver string, privateEtcdIps []string, privateIPlb, token string) resources.ScriptCollection {
+func scriptCP_N(ca, etcd, key, ver string, privateEtcdIps []string,
+	privateIPlb, token string) resources.ScriptCollection {
 
 	collection := helpers.NewScriptCollection()
 
@@ -291,7 +294,8 @@ sudo ./control-setupN.sh &>> ksctl.log
 	return collection
 }
 
-func scriptCP_NWithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string, privateIPlb, token string) resources.ScriptCollection {
+func scriptCP_NWithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string,
+	privateIPlb, token string) resources.ScriptCollection {
 
 	collection := helpers.NewScriptCollection()
 

--- a/internal/k8sdistros/k3s/controlplane.go
+++ b/internal/k8sdistros/k3s/controlplane.go
@@ -22,7 +22,8 @@ func configureCP_1(storage resources.StorageFactory, k3s *K3s, sshExecutor helpe
 			mainStateDocument.K8sBootstrap.B.EtcdKey,
 			k3s.K3sVer,
 			mainStateDocument.K8sBootstrap.B.PrivateIPs.DataStores,
-			mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer)
+			mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer,
+			mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer)
 	} else {
 		script = scriptCP_1(
 			mainStateDocument.K8sBootstrap.B.CACert,
@@ -165,7 +166,7 @@ sudo mv -v ca.pem etcd.pem etcd-key.pem /var/lib/etcd
 	}
 }
 
-func scriptCP_1WithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string, pubIPlb string) resources.ScriptCollection {
+func scriptCP_1WithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string, privIplb, pubIPlb string) resources.ScriptCollection {
 
 	collection := helpers.NewScriptCollection()
 
@@ -189,12 +190,13 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh &>> ksctl.log
-`, ver, dbEndpoint, pubIPlb),
+`, ver, dbEndpoint, pubIPlb, privIplb),
 	})
 
 	return collection

--- a/internal/k8sdistros/k3s/controlplane.go
+++ b/internal/k8sdistros/k3s/controlplane.go
@@ -193,7 +193,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 EOF
 
 sudo chmod +x control-setup.sh
-sudo ./control-setup.sh
+sudo ./control-setup.sh &>> ksctl.log
 `, ver, dbEndpoint, pubIPlb),
 	})
 
@@ -229,7 +229,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 EOF
 
 sudo chmod +x control-setupN.sh
-sudo ./control-setupN.sh
+sudo ./control-setupN.sh &>> ksctl.log
 `, ver, token, dbEndpoint, pubIPlb),
 	})
 
@@ -262,7 +262,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 EOF
 
 sudo chmod +x control-setup.sh
-sudo ./control-setup.sh
+sudo ./control-setup.sh &>> ksctl.log
 `, ver, dbEndpoint, pubIPlb),
 	})
 
@@ -311,7 +311,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 EOF
 
 sudo chmod +x control-setupN.sh
-sudo ./control-setupN.sh
+sudo ./control-setupN.sh &>> ksctl.log
 `, ver, token, dbEndpoint, pubIPlb),
 	})
 

--- a/internal/k8sdistros/k3s/k3s.go
+++ b/internal/k8sdistros/k3s/k3s.go
@@ -33,6 +33,7 @@ func NewClient(m resources.Metadata, state *types.StorageDocument) resources.Kub
 func (k3s *K3s) Setup(storage resources.StorageFactory, operation consts.KsctlOperation) error {
 	if operation == consts.OperationCreate {
 		mainStateDocument.K8sBootstrap.K3s = &types.StateConfigurationK3s{}
+		mainStateDocument.BootstrapProvider = consts.K8sK3s
 	}
 
 	if err := storage.Write(mainStateDocument); err != nil {

--- a/internal/k8sdistros/k3s/k3s_test.go
+++ b/internal/k8sdistros/k3s/k3s_test.go
@@ -137,7 +137,8 @@ func TestScriptsControlplane(t *testing.T) {
 	ver := []string{"1.26.1", "1.27"}
 	privIP := []string{"9.9.9.9", "1.1.1.1"}
 	dbEndpoint := getEtcdMemberIPFieldForControlplane(privIP)
-	pubIP := []string{"192.16.9.2", "23.34.4.1"}
+	pubIPLb := []string{"192.16.9.2", "23.34.4.1"}
+	privateIPLb := []string{"192.16.9.2", "1.1.1.1"}
 	ca, etcd, key := "-- CA_CERT --", "-- ETCD_CERT --", "-- ETCD_KEY --"
 
 	sampleToken := "k3ssdcdsXXXYYYZZZ"
@@ -168,16 +169,17 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh
-`, ver[i], dbEndpoint, pubIP[i]),
+`, ver[i], dbEndpoint, pubIPLb[i], privateIPLb[i]),
 						},
 					},
 					func() resources.ScriptCollection { // Adjust the signature to match your needs
-						return scriptCP_1WithoutCNI(ca, etcd, key, ver[i], privIP, pubIP[i])
+						return scriptCP_1WithoutCNI(ca, etcd, key, ver[i], privIP, privateIPLb[i], pubIPLb[i])
 					},
 				)
 

--- a/internal/k8sdistros/k3s/workerplane.go
+++ b/internal/k8sdistros/k3s/workerplane.go
@@ -48,6 +48,7 @@ func scriptWP(ver string, privateIPlb, token string) resources.ScriptCollection 
 		ShellScript: fmt.Sprintf(`
 cat <<EOF > worker-setup.sh
 #!/bin/bash
+export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443
 EOF
 

--- a/internal/k8sdistros/k3s/workerplane.go
+++ b/internal/k8sdistros/k3s/workerplane.go
@@ -18,11 +18,6 @@ func (k3s *K3s) JoinWorkerplane(no int, _ resources.StorageFactory) error {
 
 	log.Print("configuring Workerplane", "number", strconv.Itoa(idx))
 
-	// err := storage.Write(mainStateDocument)
-	// if err != nil {
-	// 	return log.NewError(err.Error())
-	// }
-
 	err := sshExecutor.Flag(consts.UtilExecWithoutOutput).Script(
 		scriptWP(k3s.K3sVer, mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer, mainStateDocument.K8sBootstrap.K3s.K3sToken)).
 		IPv4(mainStateDocument.K8sBootstrap.B.PublicIPs.WorkerPlanes[idx]).
@@ -48,6 +43,7 @@ func scriptWP(ver string, privateIPlb, token string) resources.ScriptCollection 
 		ShellScript: fmt.Sprintf(`
 cat <<EOF > worker-setup.sh
 #!/bin/bash
+/bin/bash /usr/local/bin/k3s-agent-uninstall.sh || echo "already deleted"
 export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443
 EOF

--- a/internal/k8sdistros/k3s/workerplane.go
+++ b/internal/k8sdistros/k3s/workerplane.go
@@ -52,7 +52,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s
 EOF
 
 sudo chmod +x worker-setup.sh
-sudo ./worker-setup.sh
+sudo ./worker-setup.sh &>> ksctl.log
 `, ver, token, privateIPlb),
 	})
 

--- a/internal/k8sdistros/kubeadm/controlplane.go
+++ b/internal/k8sdistros/kubeadm/controlplane.go
@@ -229,7 +229,7 @@ EOF
 		CanRetry:   true,
 		MaxRetries: 3,
 		ShellScript: `
-sudo kubeadm init --config kubeadm-config.yml --upload-certs
+sudo kubeadm init --config kubeadm-config.yml --upload-certs  &>> ksctl.log
 `,
 	})
 
@@ -327,7 +327,7 @@ func scriptJoinControlplane(pubIPLb, token, cacertSHA, certKey string) resources
 		MaxRetries:     3,
 		ScriptExecutor: consts.LinuxBash,
 		ShellScript: fmt.Sprintf(`
-sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s --control-plane --certificate-key %s
+sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s --control-plane --certificate-key %s  &>> ksctl.log
 `, pubIPLb, token, cacertSHA, certKey),
 	})
 	return collection

--- a/internal/k8sdistros/kubeadm/controlplane.go
+++ b/internal/k8sdistros/kubeadm/controlplane.go
@@ -220,7 +220,7 @@ controlPlaneEndpoint: "%s:6443"
 networking:
   dnsDomain: cluster.local
   serviceSubnet: 10.96.0.0/12
-  podSubnet: 10.192.0.0/12
+  podSubnet: 10.244.0.0/16
 scheduler: {}
 EOF
 

--- a/internal/k8sdistros/kubeadm/controlplane.go
+++ b/internal/k8sdistros/kubeadm/controlplane.go
@@ -220,6 +220,7 @@ controlPlaneEndpoint: "%s:6443"
 networking:
   dnsDomain: cluster.local
   serviceSubnet: 10.96.0.0/12
+  podSubnet: 10.192.0.0/12
 scheduler: {}
 EOF
 

--- a/internal/k8sdistros/kubeadm/controlplane.go
+++ b/internal/k8sdistros/kubeadm/controlplane.go
@@ -55,6 +55,7 @@ func configureCP_1(storage resources.StorageFactory, kubeadm *Kubeadm, sshExecut
 		kubeadm.KubeadmVer,
 		mainStateDocument.K8sBootstrap.Kubeadm.BootstrapToken,
 		mainStateDocument.K8sBootstrap.Kubeadm.CertificateKey,
+		mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer,
 		mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer,
 		mainStateDocument.K8sBootstrap.B.PrivateIPs.DataStores)
 
@@ -165,7 +166,7 @@ func generateExternalEtcdConfig(ips []string) string {
 	return ret.String()
 }
 
-func scriptAddKubeadmControlplane0(ver string, bootstrapToken, certificateKey, publicIPLb string, privateIPDs []string) resources.ScriptCollection {
+func scriptAddKubeadmControlplane0(ver string, bootstrapToken, certificateKey, privateIpLb string, publicIPLb string, privateIPDs []string) resources.ScriptCollection {
 
 	etcdConf := generateExternalEtcdConfig(privateIPDs)
 
@@ -200,6 +201,7 @@ apiServer:
   timeoutForControlPlane: 4m0s
   certSANs:
     - "%s"
+    - "%s"
     - "127.0.0.1"
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
@@ -221,7 +223,7 @@ networking:
 scheduler: {}
 EOF
 
-`, bootstrapToken, certificateKey, publicIPLb, etcdConf, ver, publicIPLb),
+`, bootstrapToken, certificateKey, privateIpLb, publicIPLb, etcdConf, ver, publicIPLb),
 	})
 
 	collection.Append(resources.Script{

--- a/internal/k8sdistros/kubeadm/controlplane.go
+++ b/internal/k8sdistros/kubeadm/controlplane.go
@@ -144,6 +144,7 @@ func (p *Kubeadm) ConfigureControlPlane(noOfCP int, storage resources.StorageFac
 
 			kubeconfig := sshExecutor.GetOutput()[0]
 			kubeconfig = strings.Replace(kubeconfig, "kubernetes-admin@kubernetes", mainStateDocument.ClusterName+"-"+mainStateDocument.Region+"-"+string(mainStateDocument.ClusterType)+"-"+string(mainStateDocument.InfraProvider)+"-ksctl", -1)
+			kubeconfig = strings.Replace(kubeconfig, mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer, mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer, 1)
 			mainStateDocument.ClusterKubeConfig = kubeconfig
 			log.Debug("Printing", "kubeconfig", kubeconfig)
 

--- a/internal/k8sdistros/kubeadm/kubeadm.go
+++ b/internal/k8sdistros/kubeadm/kubeadm.go
@@ -21,6 +21,7 @@ type Kubeadm struct {
 func (p *Kubeadm) Setup(storage resources.StorageFactory, operation consts.KsctlOperation) error {
 	if operation == consts.OperationCreate {
 		mainStateDocument.K8sBootstrap.Kubeadm = &types.StateConfigurationKubeadm{}
+		mainStateDocument.BootstrapProvider = consts.K8sKubeadm
 	}
 
 	if err := storage.Write(mainStateDocument); err != nil {

--- a/internal/k8sdistros/kubeadm/kubeadm.go
+++ b/internal/k8sdistros/kubeadm/kubeadm.go
@@ -45,12 +45,11 @@ func (p *Kubeadm) CNI(cni string) (externalCNI bool) {
 	switch consts.KsctlValidCNIPlugin(cni) {
 	case "":
 		p.Cni = ""
-		return false
 	default:
 		// this tells us that CNI should be installed via the k8s client
 		p.Cni = string(consts.CNINone)
-		return true
 	}
+	return true
 }
 
 func isValidKubeadmVersion(ver string) bool {

--- a/internal/k8sdistros/kubeadm/kubeadm.go
+++ b/internal/k8sdistros/kubeadm/kubeadm.go
@@ -116,11 +116,11 @@ sudo sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tabl
 		MaxRetries:     3,
 		ScriptExecutor: consts.LinuxBash,
 		ShellScript: `
-sudo apt-get update
-sudo apt-get install ca-certificates curl gnupg
+sudo apt-get update -y
+sudo apt-get install ca-certificates curl gnupg -y
 
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg --yes
 sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
 echo \
@@ -128,7 +128,7 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-sudo apt-get update
+sudo apt-get update -y
 sudo apt-get install containerd.io -y
 `,
 	})
@@ -168,11 +168,11 @@ sudo apt-get update -y
 
 sudo apt-get install -y apt-transport-https ca-certificates curl gpg
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v%s/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v%s/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg --yes
 
 echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v%s/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-sudo apt-get update
+sudo apt-get update -y
 sudo apt-get install -y kubelet kubeadm kubectl
 sudo systemctl enable kubelet
 `, ver, ver),

--- a/internal/k8sdistros/kubeadm/workerplane.go
+++ b/internal/k8sdistros/kubeadm/workerplane.go
@@ -50,7 +50,7 @@ func scriptJoinWorkerplane(collection resources.ScriptCollection, pubIPLb, token
 		MaxRetries:     3,
 		ScriptExecutor: consts.LinuxBash,
 		ShellScript: fmt.Sprintf(`
-sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s
+sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s &>> ksctl.log
 `, pubIPLb, token, cacertSHA),
 	})
 

--- a/internal/k8sdistros/kubeadm/workerplane.go
+++ b/internal/k8sdistros/kubeadm/workerplane.go
@@ -23,7 +23,7 @@ func (p *Kubeadm) JoinWorkerplane(noOfWP int, storage resources.StorageFactory) 
 
 	script := scriptJoinWorkerplane(
 		scriptInstallKubeadmAndOtherTools(p.KubeadmVer),
-		mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer,
+		mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer,
 		mainStateDocument.K8sBootstrap.Kubeadm.BootstrapToken,
 		mainStateDocument.K8sBootstrap.Kubeadm.DiscoveryTokenCACertHash,
 	)
@@ -42,7 +42,7 @@ func (p *Kubeadm) JoinWorkerplane(noOfWP int, storage resources.StorageFactory) 
 	return nil
 }
 
-func scriptJoinWorkerplane(collection resources.ScriptCollection, pubIPLb, token, cacertSHA string) resources.ScriptCollection {
+func scriptJoinWorkerplane(collection resources.ScriptCollection, privateIPLb, token, cacertSHA string) resources.ScriptCollection {
 
 	collection.Append(resources.Script{
 		Name:           "Join K3s workerplane",
@@ -51,7 +51,7 @@ func scriptJoinWorkerplane(collection resources.ScriptCollection, pubIPLb, token
 		ScriptExecutor: consts.LinuxBash,
 		ShellScript: fmt.Sprintf(`
 sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s &>> ksctl.log
-`, pubIPLb, token, cacertSHA),
+`, privateIPLb, token, cacertSHA),
 	})
 
 	return collection

--- a/internal/k8sdistros/loadbalancer.go
+++ b/internal/k8sdistros/loadbalancer.go
@@ -16,7 +16,7 @@ func (p *PreBootstrap) ConfigureLoadbalancer(_ resources.StorageFactory) error {
 	sshExecutor := helpers.NewSSHExecutor(mainStateDocument) //making sure that a new obj gets initialized for a every run thus eleminating possible problems with concurrency
 	p.mu.Unlock()
 
-	controlPlaneIPs := utilities.DeepCopySlice[string](mainStateDocument.K8sBootstrap.B.PublicIPs.ControlPlanes)
+	controlPlaneIPs := utilities.DeepCopySlice[string](mainStateDocument.K8sBootstrap.B.PrivateIPs.ControlPlanes)
 
 	err := sshExecutor.Flag(consts.UtilExecWithoutOutput).Script(
 		scriptConfigureLoadbalancer(controlPlaneIPs)).

--- a/internal/k8sdistros/loadbalancer.go
+++ b/internal/k8sdistros/loadbalancer.go
@@ -63,12 +63,6 @@ sudo systemctl enable haproxy
 `, index+1, controlPlaneIP, 6443)
 	}
 
-	nodePortScript := ""
-	for index, controlPlaneIP := range controlPlaneIPs {
-		nodePortScript += fmt.Sprintf(`  server k3sserver-%d %s
-`, index+1, controlPlaneIP)
-	}
-
 	collection.Append(resources.Script{
 		Name:           "create haproxy configuration",
 		CanRetry:       false,
@@ -82,23 +76,7 @@ frontend kubernetes-frontend
   timeout client 10s
   default_backend kubernetes-backend
 
-
-frontend kubernetes-nodeport
-  bind *:30000-35000
-  mode tcp
-  option tcplog
-  timeout client 10s
-  default_backend kubernetes-backend-nodeport
-
 backend kubernetes-backend
-  timeout connect 10s
-  timeout server 10s
-  mode tcp
-  option tcp-check
-  balance roundrobin
-%s
-
-backend kubernetes-backend-nodeport
   timeout connect 10s
   timeout server 10s
   mode tcp
@@ -108,16 +86,7 @@ backend kubernetes-backend-nodeport
 EOF
 
 sudo mv haproxy.cfg /etc/haproxy/haproxy.cfg
-`, serverScript, nodePortScript),
-	})
-
-	collection.Append(resources.Script{
-		Name:           "waiting for all cloudprovider specific ports are free for usage of range 30k-35k",
-		CanRetry:       false,
-		ScriptExecutor: consts.LinuxBash,
-		ShellScript: `
-sleep 1m
-`,
+`, serverScript),
 	})
 
 	collection.Append(resources.Script{

--- a/internal/k8sdistros/loadbalancer.go
+++ b/internal/k8sdistros/loadbalancer.go
@@ -112,6 +112,15 @@ sudo mv haproxy.cfg /etc/haproxy/haproxy.cfg
 	})
 
 	collection.Append(resources.Script{
+		Name:           "waiting for all cloudprovider specific ports are free for usage of range 30k-35k",
+		CanRetry:       false,
+		ScriptExecutor: consts.LinuxBash,
+		ShellScript: `
+sleep 1m
+`,
+	})
+
+	collection.Append(resources.Script{
 		Name:           "restarting haproxy",
 		CanRetry:       true,
 		MaxRetries:     3,

--- a/internal/k8sdistros/main.go
+++ b/internal/k8sdistros/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ksctl/ksctl/internal/storage/types"
 	"github.com/ksctl/ksctl/pkg/helpers"
 	"github.com/ksctl/ksctl/pkg/helpers/consts"
+	"github.com/ksctl/ksctl/pkg/helpers/utilities"
 	"github.com/ksctl/ksctl/pkg/logger"
 	"github.com/ksctl/ksctl/pkg/resources"
 	"github.com/ksctl/ksctl/pkg/resources/controllers/cloud"
@@ -16,7 +17,9 @@ var (
 	log               resources.LoggerFactory
 )
 
-func NewPreBootStrap(m resources.Metadata, state *types.StorageDocument) resources.PreKubernetesBootstrap {
+func NewPreBootStrap(m resources.Metadata,
+	state *types.StorageDocument) resources.PreKubernetesBootstrap {
+
 	log = logger.NewDefaultLogger(m.LogVerbosity, m.LogWritter)
 	log.SetPackageName("bootstrap")
 
@@ -24,28 +27,41 @@ func NewPreBootStrap(m resources.Metadata, state *types.StorageDocument) resourc
 	return &PreBootstrap{mu: &sync.Mutex{}}
 }
 
-func (p *PreBootstrap) Setup(cloudState cloud.CloudResourceState, storage resources.StorageFactory, operation consts.KsctlOperation) error {
+func (p *PreBootstrap) Setup(cloudState cloud.CloudResourceState,
+	storage resources.StorageFactory, operation consts.KsctlOperation) error {
 
 	if operation == consts.OperationCreate {
 		mainStateDocument.K8sBootstrap = &types.KubernetesBootstrapState{}
 		var err error
-		mainStateDocument.K8sBootstrap.B.CACert, mainStateDocument.K8sBootstrap.B.EtcdCert, mainStateDocument.K8sBootstrap.B.EtcdKey, err = helpers.GenerateCerts(log, cloudState.PrivateIPv4DataStores)
+		mainStateDocument.K8sBootstrap.B.CACert,
+			mainStateDocument.K8sBootstrap.B.EtcdCert,
+			mainStateDocument.K8sBootstrap.B.EtcdKey,
+			err = helpers.GenerateCerts(log, cloudState.PrivateIPv4DataStores)
 		if err != nil {
 			return err
 		}
 	}
 
-	// TODO: use deepCopy()
-	mainStateDocument.K8sBootstrap.B.PublicIPs.ControlPlanes = cloudState.IPv4ControlPlanes
-	mainStateDocument.K8sBootstrap.B.PrivateIPs.ControlPlanes = cloudState.PrivateIPv4ControlPlanes
+	mainStateDocument.K8sBootstrap.B.PublicIPs.ControlPlanes =
+		utilities.DeepCopySlice[string](cloudState.IPv4ControlPlanes)
 
-	mainStateDocument.K8sBootstrap.B.PublicIPs.DataStores = cloudState.IPv4DataStores
-	mainStateDocument.K8sBootstrap.B.PrivateIPs.DataStores = cloudState.PrivateIPv4DataStores
+	mainStateDocument.K8sBootstrap.B.PrivateIPs.ControlPlanes =
+		utilities.DeepCopySlice[string](cloudState.PrivateIPv4ControlPlanes)
 
-	mainStateDocument.K8sBootstrap.B.PublicIPs.WorkerPlanes = cloudState.IPv4WorkerPlanes
+	mainStateDocument.K8sBootstrap.B.PublicIPs.DataStores =
+		utilities.DeepCopySlice[string](cloudState.IPv4DataStores)
+	mainStateDocument.K8sBootstrap.B.PrivateIPs.DataStores =
+		utilities.DeepCopySlice[string](cloudState.PrivateIPv4DataStores)
 
-	mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer = cloudState.IPv4LoadBalancer
-	mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer = cloudState.PrivateIPv4LoadBalancer
+	mainStateDocument.K8sBootstrap.B.PublicIPs.WorkerPlanes =
+		utilities.DeepCopySlice[string](cloudState.IPv4WorkerPlanes)
+
+	mainStateDocument.K8sBootstrap.B.PublicIPs.LoadBalancer =
+		cloudState.IPv4LoadBalancer
+
+	mainStateDocument.K8sBootstrap.B.PrivateIPs.LoadBalancer =
+		cloudState.PrivateIPv4LoadBalancer
+
 	mainStateDocument.K8sBootstrap.B.SSHInfo = cloudState.SSHState
 
 	if err := storage.Write(mainStateDocument); err != nil {

--- a/internal/kubernetes/applications.go
+++ b/internal/kubernetes/applications.go
@@ -41,6 +41,7 @@ func initApps() {
 		"prometheus-stack":  prometheusStackData,
 		"ksctl-storage":     storageImportData,
 		"ksctl-application": applicationStackData,
+		"flannel":           flannelData,
 	}
 }
 

--- a/internal/kubernetes/applications.go
+++ b/internal/kubernetes/applications.go
@@ -18,7 +18,6 @@ const (
 type Application struct {
 	Name          string
 	Url           string
-	Namespace     string
 	Version       string
 	Metadata      string
 	Maintainer    string

--- a/internal/kubernetes/appsv1.go
+++ b/internal/kubernetes/appsv1.go
@@ -9,6 +9,28 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
+func (k *Kubernetes) daemonsetApply(o *appsv1.DaemonSet, ns string) error {
+
+	_, err := k.clientset.
+		AppsV1().
+		DaemonSets(ns).
+		Create(context.Background(), o, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			_, err = k.clientset.
+				AppsV1().
+				DaemonSets(ns).
+				Update(context.Background(), o, metav1.UpdateOptions{})
+			if err != nil {
+				return log.NewError(err.Error())
+			}
+		} else {
+			return log.NewError(err.Error())
+		}
+	}
+	return nil
+}
+
 func (k *Kubernetes) deploymentApply(o *appsv1.Deployment, ns string) error {
 
 	_, err := k.clientset.
@@ -27,6 +49,17 @@ func (k *Kubernetes) deploymentApply(o *appsv1.Deployment, ns string) error {
 		} else {
 			return log.NewError(err.Error())
 		}
+	}
+	return nil
+}
+
+func (k *Kubernetes) daemonsetDelete(o *appsv1.DaemonSet, ns string) error {
+	err := k.clientset.
+		AppsV1().
+		DaemonSets(ns).
+		Delete(context.Background(), o.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return log.NewError(err.Error())
 	}
 	return nil
 }

--- a/internal/kubernetes/argocd.go
+++ b/internal/kubernetes/argocd.go
@@ -6,7 +6,6 @@ func argocdData(ver string) Application {
 	return Application{
 		Name:       "argocd",
 		Url:        fmt.Sprintf("https://raw.githubusercontent.com/argoproj/argo-cd/%s/manifests/install.yaml", ver),
-		Namespace:  "argocd",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Argo CD (Ver: %s) is a declarative, GitOps continuous delivery tool for Kubernetes.", ver),
@@ -16,7 +15,10 @@ Commands to execute to access Argocd
 	$ kubectl port-forward svc/argocd-server -n argocd 8080:443
 and login to http://localhost:8080 with user admin and password from above
 		`,
-		InstallType:   InstallKubectl,
-		KubectlConfig: KubectlOptions{createNamespace: true},
+		InstallType: InstallKubectl,
+		KubectlConfig: KubectlOptions{
+			createNamespace: true,
+			namespace:       "argocd",
+		},
 	}
 }

--- a/internal/kubernetes/argorollout.go
+++ b/internal/kubernetes/argorollout.go
@@ -8,7 +8,6 @@ func argoRolloutsData(ver string) Application {
 	return Application{
 		Name:       "argo-rollouts",
 		Url:        fmt.Sprintf("https://github.com/argoproj/argo-rollouts/releases/download/%s/install.yaml", ver),
-		Namespace:  "argo-rollouts",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Argo Rollouts (Ver: %s) is a Kubernetes controller and set of CRDs which provide advanced deployment capabilities such as blue-green, canary, canary analysis, experimentation, and progressive delivery features to Kubernetes.", ver),
@@ -18,7 +17,10 @@ Commands to execute to access Argo-Rollouts
 	$ kubectl argo rollouts dashboard
 and open http://localhost:3100/rollouts
 		`,
-		InstallType:   InstallKubectl,
-		KubectlConfig: KubectlOptions{createNamespace: true},
+		InstallType: InstallKubectl,
+		KubectlConfig: KubectlOptions{
+			createNamespace: true,
+			namespace:       "argo-rollouts",
+		},
 	}
 }

--- a/internal/kubernetes/batchv1.go
+++ b/internal/kubernetes/batchv1.go
@@ -8,7 +8,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (k *Kubernetes) jobApply(o *batchv1.Job, ns string) error {
+func (k *Kubernetes) jobApply(o *batchv1.Job) error {
+	ns := o.Namespace
 
 	_, err := k.clientset.
 		BatchV1().
@@ -29,7 +30,8 @@ func (k *Kubernetes) jobApply(o *batchv1.Job, ns string) error {
 	}
 	return nil
 }
-func (k *Kubernetes) jobDelete(o *batchv1.Job, ns string) error {
+func (k *Kubernetes) jobDelete(o *batchv1.Job) error {
+	ns := o.Namespace
 
 	err := k.clientset.
 		BatchV1().

--- a/internal/kubernetes/cilium.go
+++ b/internal/kubernetes/cilium.go
@@ -5,7 +5,6 @@ import "fmt"
 func ciliumData(ver string) Application {
 	return Application{
 		Name:       "cilium",
-		Namespace:  "<Helm-Managed>",
 		Url:        "https://helm.cilium.io/",
 		Maintainer: "Dipankar Das",
 		Version:    ver,

--- a/internal/kubernetes/flannel.go
+++ b/internal/kubernetes/flannel.go
@@ -1,0 +1,22 @@
+package kubernetes
+
+import "fmt"
+
+func flannelData(ver string) Application {
+	if ver == "stable" {
+		ver = "latest"
+	}
+	return Application{
+		Name:       "flannel",
+		Url:        fmt.Sprintf("https://github.com/flannel-io/flannel/releases/%s/download/kube-flannel.yml", ver),
+		Namespace:  "flannel",
+		Maintainer: "Dipankar Das",
+		Version:    ver,
+		Metadata:   fmt.Sprintf("Flannel (Ver: %s) is a simple and easy way to configure a layer 3 network fabric designed for Kubernetes.", ver),
+		PostInstall: `
+None
+		`,
+		InstallType:   InstallKubectl,
+		KubectlConfig: KubectlOptions{createNamespace: false},
+	}
+}

--- a/internal/kubernetes/flannel.go
+++ b/internal/kubernetes/flannel.go
@@ -9,7 +9,6 @@ func flannelData(ver string) Application {
 	return Application{
 		Name:       "flannel",
 		Url:        fmt.Sprintf("https://github.com/flannel-io/flannel/releases/%s/download/kube-flannel.yml", ver),
-		Namespace:  "kube-flannel",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Flannel (Ver: %s) is a simple and easy way to configure a layer 3 network fabric designed for Kubernetes.", ver),

--- a/internal/kubernetes/flannel.go
+++ b/internal/kubernetes/flannel.go
@@ -9,7 +9,7 @@ func flannelData(ver string) Application {
 	return Application{
 		Name:       "flannel",
 		Url:        fmt.Sprintf("https://github.com/flannel-io/flannel/releases/%s/download/kube-flannel.yml", ver),
-		Namespace:  "flannel",
+		Namespace:  "kube-flannel",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Flannel (Ver: %s) is a simple and easy way to configure a layer 3 network fabric designed for Kubernetes.", ver),

--- a/internal/kubernetes/istio.go
+++ b/internal/kubernetes/istio.go
@@ -5,7 +5,6 @@ import "fmt"
 func istioData(ver string) Application {
 	return Application{
 		Name:       "istio",
-		Namespace:  "<Helm-Managed>",
 		Url:        "https://istio-release.storage.googleapis.com/charts",
 		Maintainer: "Dipankar Das",
 		Version:    ver,

--- a/internal/kubernetes/ksctl_controllers.go
+++ b/internal/kubernetes/ksctl_controllers.go
@@ -9,7 +9,6 @@ func storageImportData(ver string) Application {
 	return Application{
 		Name:       "ksctl-import-data",
 		Url:        fmt.Sprintf("https://raw.githubusercontent.com/ksctl/ksctl/%s/ksctl-components/manifests/controllers/storage/deploy.yml", ver),
-		Namespace:  "ksctl",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Ksctl Storage controller (Ver: %s)", ver),
@@ -28,7 +27,6 @@ func applicationStackData(ver string) Application {
 	return Application{
 		Name:       "ksctl-appplication-stack",
 		Url:        fmt.Sprintf("https://raw.githubusercontent.com/ksctl/ksctl/%s/ksctl-components/manifests/controllers/application/deploy.yml", ver),
-		Namespace:  "ksctl",
 		Maintainer: "Dipankar Das",
 		Version:    ver,
 		Metadata:   fmt.Sprintf("Ksctl Application controller (Ver: %s)", ver),

--- a/internal/kubernetes/kubectl.go
+++ b/internal/kubernetes/kubectl.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -61,52 +62,56 @@ func deleteKubectl(client *Kubernetes, appStruct Application) error {
 			errRes = client.apiExtensionsDelete(o)
 
 		case *corev1.Namespace:
-			log.Debug("Namespace", "name", o.Name)
+			log.Print("Namespace", "name", o.Name)
+			appStruct.Namespace = o.Name
 			errRes = client.namespaceDeleteManifest(o)
 
-		case *appsv1.Deployment:
+		case *appsv1.DaemonSet:
+			log.Print("Daemonset", "name", o.Name)
+			errRes = client.daemonsetDelete(o, appStruct.Namespace)
 
-			log.Debug("Deployment", "name", o.Name)
+		case *appsv1.Deployment:
+			log.Print("Deployment", "name", o.Name)
 			errRes = client.deploymentDelete(o, appStruct.Namespace)
 
 		case *corev1.Service:
-			log.Debug("Service", "name", o.Name)
+			log.Print("Service", "name", o.Name)
 			errRes = client.serviceDelete(o, appStruct.Namespace)
 
 		case *corev1.ServiceAccount:
-			log.Debug("ServiceAccount", "name", o.Name)
+			log.Print("ServiceAccount", "name", o.Name)
 			errRes = client.serviceAccountDelete(o, appStruct.Namespace)
 
 		case *corev1.ConfigMap:
-			log.Debug("ConfigMap", "name", o.Name)
+			log.Print("ConfigMap", "name", o.Name)
 			errRes = client.configMapDelete(o, appStruct.Namespace)
 
 		case *corev1.Secret:
-			log.Debug("Secret", "name", o.Name)
+			log.Print("Secret", "name", o.Name)
 			errRes = client.secretDelete(o, appStruct.Namespace)
 
 		case *appsv1.StatefulSet:
-			log.Debug("StatefulSet", "name", o.Name)
+			log.Print("StatefulSet", "name", o.Name)
 			errRes = client.statefulSetDelete(o, appStruct.Namespace)
 
 		case *rbacv1.ClusterRole:
-			log.Debug("ClusterRole", "name", o.Name)
+			log.Print("ClusterRole", "name", o.Name)
 			errRes = client.clusterRoleDelete(o)
 
 		case *rbacv1.ClusterRoleBinding:
-			log.Debug("ClusterRoleBinding", "name", o.Name)
+			log.Print("ClusterRoleBinding", "name", o.Name)
 			errRes = client.clusterRoleBindingDelete(o)
 
 		case *rbacv1.Role:
-			log.Debug("Role", "name", o.Name)
+			log.Print("Role", "name", o.Name)
 			errRes = client.roleDelete(o, appStruct.Namespace)
 
 		case *rbacv1.RoleBinding:
-			log.Debug("RoleBinding", "name", o.Name)
+			log.Print("RoleBinding", "name", o.Name)
 			errRes = client.roleBindingDelete(o, appStruct.Namespace)
 
 		case *networkingv1.NetworkPolicy:
-			log.Debug("NetworkPolicy", "name", o.Name)
+			log.Print("NetworkPolicy", "name", o.Name)
 			errRes = client.netPolicyDelete(o, appStruct.Namespace)
 
 		default:
@@ -140,6 +145,7 @@ func installKubectl(client *Kubernetes, appStruct Application) error {
 	}
 
 	for _, resource := range resources {
+		fmt.Println(resource)
 		decUnstructured := scheme.Codecs.UniversalDeserializer().Decode
 
 		obj, _, err := decUnstructured([]byte(resource), nil, nil)
@@ -155,52 +161,57 @@ func installKubectl(client *Kubernetes, appStruct Application) error {
 			errRes = client.apiExtensionsApply(o)
 
 		case *corev1.Namespace:
-			log.Debug("Namespace", "name", o.Name)
+			log.Print("Namespace", "name", o.Name)
+			// FIXED: as the naemspace is the first object being created change the existing one
+			appStruct.Namespace = o.Name
 			errRes = client.namespaceCreateManifest(o)
 
-		case *appsv1.Deployment:
+		case *appsv1.DaemonSet:
+			log.Print("Daemonset", "name", o.Name)
+			errRes = client.daemonsetApply(o, appStruct.Namespace)
 
-			log.Debug("Deployment", "name", o.Name)
+		case *appsv1.Deployment:
+			log.Print("Deployment", "name", o.Name)
 			errRes = client.deploymentApply(o, appStruct.Namespace)
 
 		case *corev1.Service:
-			log.Debug("Service", "name", o.Name)
+			log.Print("Service", "name", o.Name)
 			errRes = client.serviceApply(o, appStruct.Namespace)
 
 		case *corev1.ServiceAccount:
-			log.Debug("ServiceAccount", "name", o.Name)
+			log.Print("ServiceAccount", "name", o.Name)
 			errRes = client.serviceAccountApply(o, appStruct.Namespace)
 
 		case *corev1.ConfigMap:
-			log.Debug("ConfigMap", "name", o.Name)
+			log.Print("ConfigMap", "name", o.Name)
 			errRes = client.configMapApply(o, appStruct.Namespace)
 
 		case *corev1.Secret:
-			log.Debug("Secret", "name", o.Name)
+			log.Print("Secret", "name", o.Name)
 			errRes = client.secretApply(o, appStruct.Namespace)
 
 		case *appsv1.StatefulSet:
-			log.Debug("StatefulSet", "name", o.Name)
+			log.Print("StatefulSet", "name", o.Name)
 			errRes = client.statefulSetApply(o, appStruct.Namespace)
 
 		case *rbacv1.ClusterRole:
-			log.Debug("ClusterRole", "name", o.Name)
+			log.Print("ClusterRole", "name", o.Name)
 			errRes = client.clusterRoleApply(o)
 
 		case *rbacv1.ClusterRoleBinding:
-			log.Debug("ClusterRoleBinding", "name", o.Name)
+			log.Print("ClusterRoleBinding", "name", o.Name)
 			errRes = client.clusterRoleBindingApply(o)
 
 		case *rbacv1.Role:
-			log.Debug("Role", "name", o.Name)
+			log.Print("Role", "name", o.Name)
 			errRes = client.roleApply(o, appStruct.Namespace)
 
 		case *rbacv1.RoleBinding:
-			log.Debug("RoleBinding", "name", o.Name)
+			log.Print("RoleBinding", "name", o.Name)
 			errRes = client.roleBindingApply(o, appStruct.Namespace)
 
 		case *networkingv1.NetworkPolicy:
-			log.Debug("NetworkPolicy", "name", o.Name)
+			log.Print("NetworkPolicy", "name", o.Name)
 			errRes = client.netPolicyApply(o, appStruct.Namespace)
 
 		default:

--- a/internal/kubernetes/kubectl.go
+++ b/internal/kubernetes/kubectl.go
@@ -60,6 +60,10 @@ func deleteKubectl(client *Kubernetes, appStruct Application) error {
 		case *apiextensionsv1.CustomResourceDefinition:
 			errRes = client.apiExtensionsDelete(o)
 
+		case *corev1.Namespace:
+			log.Debug("Namespace", "name", o.Name)
+			errRes = client.namespaceDeleteManifest(o)
+
 		case *appsv1.Deployment:
 
 			log.Debug("Deployment", "name", o.Name)
@@ -149,6 +153,10 @@ func installKubectl(client *Kubernetes, appStruct Application) error {
 
 		case *apiextensionsv1.CustomResourceDefinition:
 			errRes = client.apiExtensionsApply(o)
+
+		case *corev1.Namespace:
+			log.Debug("Namespace", "name", o.Name)
+			errRes = client.namespaceCreateManifest(o)
 
 		case *appsv1.Deployment:
 

--- a/internal/kubernetes/kubectl.go
+++ b/internal/kubernetes/kubectl.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -190,7 +189,6 @@ func installKubectl(client *Kubernetes, appStruct Application) error {
 	}
 
 	for _, resource := range resources {
-		fmt.Println(resource)
 		decUnstructured := scheme.Codecs.UniversalDeserializer().Decode
 
 		obj, _, err := decUnstructured([]byte(resource), nil, nil)

--- a/internal/kubernetes/networkingv1.go
+++ b/internal/kubernetes/networkingv1.go
@@ -8,8 +8,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (k *Kubernetes) netPolicyApply(o *networkingv1.NetworkPolicy, ns string) error {
+func (k *Kubernetes) netPolicyApply(o *networkingv1.NetworkPolicy) error {
 
+	ns := o.Namespace
 	_, err := k.clientset.
 		NetworkingV1().
 		NetworkPolicies(ns).
@@ -30,8 +31,9 @@ func (k *Kubernetes) netPolicyApply(o *networkingv1.NetworkPolicy, ns string) er
 	return nil
 }
 
-func (k *Kubernetes) netPolicyDelete(o *networkingv1.NetworkPolicy, ns string) error {
+func (k *Kubernetes) netPolicyDelete(o *networkingv1.NetworkPolicy) error {
 
+	ns := o.Namespace
 	err := k.clientset.
 		NetworkingV1().
 		NetworkPolicies(ns).

--- a/internal/kubernetes/prometheusStack.go
+++ b/internal/kubernetes/prometheusStack.go
@@ -6,7 +6,6 @@ func prometheusStackData(ver string) Application {
 
 	return Application{
 		Name:       "prometheus-community",
-		Namespace:  "<Helm-Managed>",
 		Url:        "https://prometheus-community.github.io/helm-charts",
 		Maintainer: "Dipankar Das",
 		Version:    ver,

--- a/internal/kubernetes/rbacv1.go
+++ b/internal/kubernetes/rbacv1.go
@@ -76,11 +76,11 @@ func (k *Kubernetes) clusterRoleBindingApply(o *rbacv1.ClusterRoleBinding) error
 	return nil
 }
 
-func (k *Kubernetes) roleDelete(o *rbacv1.Role, ns string) error {
+func (k *Kubernetes) roleDelete(o *rbacv1.Role) error {
 
 	err := k.clientset.
 		RbacV1().
-		Roles(ns).
+		Roles(o.Namespace).
 		Delete(context.Background(), o.Name, v1.DeleteOptions{})
 	if err != nil {
 		return log.NewError(err.Error())
@@ -88,8 +88,9 @@ func (k *Kubernetes) roleDelete(o *rbacv1.Role, ns string) error {
 	return nil
 }
 
-func (k *Kubernetes) roleApply(o *rbacv1.Role, ns string) error {
+func (k *Kubernetes) roleApply(o *rbacv1.Role) error {
 
+	ns := o.Namespace
 	_, err := k.clientset.
 		RbacV1().
 		Roles(ns).
@@ -110,7 +111,8 @@ func (k *Kubernetes) roleApply(o *rbacv1.Role, ns string) error {
 	return nil
 }
 
-func (k *Kubernetes) roleBindingApply(o *rbacv1.RoleBinding, ns string) error {
+func (k *Kubernetes) roleBindingApply(o *rbacv1.RoleBinding) error {
+	ns := o.Namespace
 
 	_, err := k.clientset.
 		RbacV1().
@@ -132,7 +134,8 @@ func (k *Kubernetes) roleBindingApply(o *rbacv1.RoleBinding, ns string) error {
 	return nil
 }
 
-func (k *Kubernetes) roleBindingDelete(o *rbacv1.RoleBinding, ns string) error {
+func (k *Kubernetes) roleBindingDelete(o *rbacv1.RoleBinding) error {
+	ns := o.Namespace
 
 	err := k.clientset.
 		RbacV1().

--- a/internal/storage/types/aws.go
+++ b/internal/storage/types/aws.go
@@ -1,75 +1,59 @@
 package types
 
-import "github.com/ksctl/ksctl/pkg/helpers/consts"
-
 type AWSStateVm struct {
-	Vpc                  string `json:"vpc"`
-	HostName             string `json:"name"`
-	DiskSize             string `json:"disk_size"`
-	InstanceType         string `json:"instance_type"`
-	InstanceID           string `json:"instance_id"`
-	Subnet               string `json:"subnet"`
-	NetworkSecurityGroup string `json:"network_security_group"`
-	PublicIP             string `json:"public_ip"`
-	PrivateIP            string `json:"private_ip"`
-	NetworkInterfaceId   string `json:"network_interface_id"`
+	Vpc                  string `json:"vpc" bson:"vpc"`
+	HostName             string `json:"name" bson:"name"`
+	DiskSize             string `json:"disk_size" bson:"disk_size"`
+	InstanceType         string `json:"instance_type" bson:"instance_type"`
+	InstanceID           string `json:"instance_id" bson:"instance_id"`
+	Subnet               string `json:"subnet" bson:"subnet"`
+	NetworkSecurityGroup string `json:"network_security_group" bson:"network_security_group"`
+	PublicIP             string `json:"public_ip" bson:"public_ip"`
+	PrivateIP            string `json:"private_ip" bson:"private_ip"`
+	NetworkInterfaceId   string `json:"network_interface_id" bson:"network_interface_id"`
 }
+
 type CredentialsAws struct {
-	AcessKeyID     string
-	AcessKeySecret string
+	AccessKeyId     string `json:"access_key_id" bson:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key" bson:"secret_access_key"`
 }
-type metadata struct {
-	resName string
-	role    consts.KsctlRole
-	vmType  string
-	public  bool
 
-	apps    string
-	cni     string
-	version string
-
-	noCP int
-	noWP int
-	noDS int
-
-	k8sName    consts.KsctlKubernetes
-	k8sVersion string
-}
 type AWSStateVms struct {
-	HostNames            []string `json:"names"`
-	DiskNames            []string `json:"disk_name"`
-	InstanceIds          []string `json:"instance_id"`
-	PrivateIPs           []string `json:"private_ip"`
-	PublicIPs            []string `json:"public_ip"`
-	NetworkInterfaceIDs  []string `json:"network_interface_id"`
-	SubnetNames          []string `json:"subnet_name"`
-	SubnetIDs            []string `json:"subnet_id"`
-	NetworkSecurityGroup string   `json:"network_security_group"`
+	HostNames            []string `json:"names" bson:"name"`
+	DiskNames            []string `json:"disk_name" bson:"disk_name"`
+	InstanceIds          []string `json:"instance_id" bson:"instance_id"`
+	PrivateIPs           []string `json:"private_ip" bson:"private_ip"`
+	PublicIPs            []string `json:"public_ip" bson:"public_ip"`
+	NetworkInterfaceIDs  []string `json:"network_interface_id" bson:"network_interface_id"`
+	SubnetNames          []string `json:"subnet_name" bson:"subnet_name"`
+	SubnetIDs            []string `json:"subnet_id" bson:"subnet_id"`
+	NetworkSecurityGroup string   `json:"network_security_group" bson:"network_security_group"`
 }
 
 type StateConfigurationAws struct {
 	B BaseInfra `json:"b" bson:"b"`
 
 	IsCompleted bool
-	ClusterName string `json:"cluster_name"`
-	Region      string `json:"region"`
-	VpcName     string `json:"vpc"`
-	VpcId       string `json:"vpc_id"`
+	ClusterName string `json:"cluster_name" bson:"cluster_name"`
+	Region      string `json:"region" bson:"region"`
+	VpcName     string `json:"vpc" bson:"vpc"`
+	VpcId       string `json:"vpc_id" bson:"vpc_id"`
+	VpcCidr     string `json:"vpc_cidr" bson:"vpc_cidr"`
 
-	ManagedClusterName string `json:"managed_cluster_name"`
-	NoManagedNodes     int    `json:"no_managed_nodes"`
-	SubnetName         string `json:"subnet_name"`
-	SubnetID           string `json:"subnet_id"`
-	NetworkAclID       string `json:"network_acl_id"`
+	ManagedClusterName string `json:"managed_cluster_name" bson:"managed_cluster_name"`
+	NoManagedNodes     int    `json:"no_managed_nodes" bson:"no_managed_nodes"`
+	SubnetName         string `json:"subnet_name" bson:"subnet_name"`
+	SubnetID           string `json:"subnet_id" bson:"subnet_id"`
+	NetworkAclID       string `json:"network_acl_id" bson:"network_acl_id"`
 
-	GatewayID    string `json:"gateway_id"`
-	RouteTableID string `json:"route_table_id"`
+	GatewayID    string `json:"gateway_id" bson:"gateway_id"`
+	RouteTableID string `json:"route_table_id" bson:"route_table_id"`
 
-	InfoControlPlanes AWSStateVms `json:"info_control_planes"`
-	InfoWorkerPlanes  AWSStateVms `json:"info_worker_planes"`
-	InfoDatabase      AWSStateVms `json:"info_database"`
-	InfoLoadBalancer  AWSStateVm  `json:"info_load_balancer"`
+	InfoControlPlanes AWSStateVms `json:"info_control_planes" bson:"info_control_planes"`
+	InfoWorkerPlanes  AWSStateVms `json:"info_worker_planes" bson:"info_worker_planes"`
+	InfoDatabase      AWSStateVms `json:"info_database" bson:"info_database"`
+	InfoLoadBalancer  AWSStateVm  `json:"info_load_balancer" bson:"info_load_balancer"`
 
-	KubernetesDistro string `json:"k8s_distro"`
-	KubernetesVer    string `json:"k8s_version"`
+	KubernetesDistro string `json:"k8s_distro" bson:"k8s_distro"`
+	KubernetesVer    string `json:"k8s_version" bson:"k8s_version"`
 }

--- a/internal/storage/types/azure.go
+++ b/internal/storage/types/azure.go
@@ -43,12 +43,14 @@ type StateConfigurationAzure struct {
 	ManagedClusterName string `json:"managed_cluster_name" bson:"managed_cluster_name"`
 	NoManagedNodes     int    `json:"no_managed_cluster_nodes" bson:"no_managed_cluster_nodes"`
 
-	SubnetName         string        `json:"subnet_name" bson:"subnet_name"`
-	SubnetID           string        `json:"subnet_id" bson:"subnet_id"`
-	VirtualNetworkName string        `json:"virtual_network_name" bson:"virtual_network_name"`
-	VirtualNetworkID   string        `json:"virtual_network_id" bson:"virtual_network_id"`
-	InfoControlPlanes  AzureStateVMs `json:"info_control_planes" bson:"info_control_planes"`
-	InfoWorkerPlanes   AzureStateVMs `json:"info_worker_planes" bson:"info_worker_planes"`
-	InfoDatabase       AzureStateVMs `json:"info_database" bson:"info_database"`
-	InfoLoadBalancer   AzureStateVM  `json:"info_load_balancer" bson:"info_load_balancer"`
+	SubnetName         string `json:"subnet_name" bson:"subnet_name"`
+	SubnetID           string `json:"subnet_id" bson:"subnet_id"`
+	VirtualNetworkName string `json:"virtual_network_name" bson:"virtual_network_name"`
+	VirtualNetworkID   string `json:"virtual_network_id" bson:"virtual_network_id"`
+	NetCidr            string `json:"net_cidr" bson:"net_cidr"`
+
+	InfoControlPlanes AzureStateVMs `json:"info_control_planes" bson:"info_control_planes"`
+	InfoWorkerPlanes  AzureStateVMs `json:"info_worker_planes" bson:"info_worker_planes"`
+	InfoDatabase      AzureStateVMs `json:"info_database" bson:"info_database"`
+	InfoLoadBalancer  AzureStateVM  `json:"info_load_balancer" bson:"info_load_balancer"`
 }

--- a/internal/storage/types/civo.go
+++ b/internal/storage/types/civo.go
@@ -29,6 +29,7 @@ type StateConfigurationCivo struct {
 	FirewallIDLoadBalancer  string `json:"fwidloadbalancenode" bson:"fwidloadbalancenode"`
 	FirewallIDDatabaseNodes string `json:"fwiddatabasenode" bson:"fwiddatabasenode"`
 	NetworkID               string `json:"clusternetworkid" bson:"clusternetworkid"`
+	NetworkCIDR             string `json:"clusternetworkcidr" bson:"clusternetworkcidr"`
 
 	InfoControlPlanes CivoStateVMs `json:"info_control_planes" bson:"info_control_planes"`
 	InfoWorkerPlanes  CivoStateVMs `json:"info_worker_planes" bson:"info_worker_planes"`

--- a/pkg/controllers/kubernetes/kubernetes.go
+++ b/pkg/controllers/kubernetes/kubernetes.go
@@ -251,12 +251,18 @@ func InstallAdditionalTools(externalCNI, externalApp bool, client *resources.Ksc
 	}
 
 	if externalCNI {
+		var cni string
+		if len(client.Metadata.CNIPlugin) == 0 {
+			cni = "flannel"
+		} else {
+			cni = client.Metadata.CNIPlugin
+		}
 
-		_cni, err := helpers.ToApplicationTempl([]string{client.Metadata.CNIPlugin})
+		_cni, err := helpers.ToApplicationTempl([]string{cni})
 		if err != nil {
 			return err
 		}
-		// Note: the CNI installer is only for one!
+
 		if err := kubernetesClient.InstallCNI(_cni[0], state, consts.OperationCreate); err != nil {
 			return log.NewError(err.Error())
 		}

--- a/pkg/helpers/consts/consts.go
+++ b/pkg/helpers/consts/consts.go
@@ -26,6 +26,23 @@ type KsctlSupportedScriptRunners string
 
 type KsctlSearchFilter string
 
+type FirewallRuleProtocol int
+
+type FirewallRuleAction int
+
+type FirewallRuleDirection int
+
+const (
+	FirewallActionAllow FirewallRuleAction = iota
+	FirewallActionDeny  FirewallRuleAction = iota
+
+	FirewallActionIngress FirewallRuleDirection = iota
+	FirewallActionEgress  FirewallRuleDirection = iota
+
+	FirewallActionTCP FirewallRuleProtocol = iota
+	FirewallActionUDP FirewallRuleProtocol = iota
+)
+
 const (
 	Cloud       KsctlSearchFilter = "cloud"
 	ClusterType KsctlSearchFilter = "clusterType"

--- a/pkg/helpers/firewall_rules.go
+++ b/pkg/helpers/firewall_rules.go
@@ -6,6 +6,7 @@ import (
 
 type FirewallRule struct {
 	Description string
+	Name        string
 	Protocol    consts.FirewallRuleProtocol
 	Direction   consts.FirewallRuleDirection
 	Action      consts.FirewallRuleAction
@@ -17,6 +18,7 @@ type FirewallRule struct {
 
 func firewallRuleSSH() FirewallRule {
 	return FirewallRule{
+		Name:        "ksctl_ssh",
 		Description: "SSH port for ksctl to work",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -30,6 +32,7 @@ func firewallRuleSSH() FirewallRule {
 
 func firewallRuleOutBoundAllUDP() FirewallRule {
 	return FirewallRule{
+		Name:        "all_udp_outgoing",
 		Description: "enable all the UDP outgoing traffic",
 		Protocol:    consts.FirewallActionUDP,
 		Direction:   consts.FirewallActionEgress,
@@ -43,6 +46,7 @@ func firewallRuleOutBoundAllUDP() FirewallRule {
 
 func firewallRuleOutBoundAllTCP() FirewallRule {
 	return FirewallRule{
+		Name:        "all_tcp_outgoing",
 		Description: "enable all the TCP outgoing traffic",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionEgress,
@@ -56,6 +60,7 @@ func firewallRuleOutBoundAllTCP() FirewallRule {
 
 func firewallRuleKubeApiServer(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "kubernetes_api_server",
 		Description: "Kubernetes API Server",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -69,6 +74,7 @@ func firewallRuleKubeApiServer(cidr string) FirewallRule {
 
 func firewallRuleKubeletApi(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "kubelet_api",
 		Description: "Kubelet API",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -82,6 +88,7 @@ func firewallRuleKubeletApi(cidr string) FirewallRule {
 
 func firewallRuleFlannel_VXLAN(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "cni_flannel_vxlan",
 		Description: "Required only for Flannel VXLAN",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -95,6 +102,7 @@ func firewallRuleFlannel_VXLAN(cidr string) FirewallRule {
 
 func firewallRuleKubeProxy(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "kubernetes_kube_proxy",
 		Description: "kube-proxy",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -108,6 +116,7 @@ func firewallRuleKubeProxy(cidr string) FirewallRule {
 
 func firewallRuleNodePort(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "kubernetes_nodeport",
 		Description: "NodePort Services",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,
@@ -121,6 +130,7 @@ func firewallRuleNodePort(cidr string) FirewallRule {
 
 func firewallRuleEtcd(cidr string) FirewallRule {
 	return FirewallRule{
+		Name:        "etcd",
 		Description: "For HA with external etcd",
 		Protocol:    consts.FirewallActionTCP,
 		Direction:   consts.FirewallActionIngress,

--- a/pkg/helpers/firewall_rules.go
+++ b/pkg/helpers/firewall_rules.go
@@ -90,7 +90,7 @@ func firewallRuleFlannel_VXLAN(cidr string) FirewallRule {
 	return FirewallRule{
 		Name:        "cni_flannel_vxlan",
 		Description: "Required only for Flannel VXLAN",
-		Protocol:    consts.FirewallActionTCP,
+		Protocol:    consts.FirewallActionUDP,
 		Direction:   consts.FirewallActionIngress,
 		Action:      consts.FirewallActionAllow,
 

--- a/pkg/helpers/firewall_rules.go
+++ b/pkg/helpers/firewall_rules.go
@@ -1,0 +1,200 @@
+package helpers
+
+import (
+	"github.com/ksctl/ksctl/pkg/helpers/consts"
+)
+
+type FirewallRule struct {
+	Description string
+	Protocol    consts.FirewallRuleProtocol
+	Direction   consts.FirewallRuleDirection
+	Action      consts.FirewallRuleAction
+
+	Cidr      string
+	StartPort string
+	EndPort   string
+}
+
+func firewallRuleSSH() FirewallRule {
+	return FirewallRule{
+		Description: "SSH port for ksctl to work",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "22",
+		EndPort:   "22",
+	}
+}
+
+func firewallRuleOutBoundAllUDP() FirewallRule {
+	return FirewallRule{
+		Description: "enable all the UDP outgoing traffic",
+		Protocol:    consts.FirewallActionUDP,
+		Direction:   consts.FirewallActionEgress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "1",
+		EndPort:   "65535",
+	}
+}
+
+func firewallRuleOutBoundAllTCP() FirewallRule {
+	return FirewallRule{
+		Description: "enable all the TCP outgoing traffic",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionEgress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "1",
+		EndPort:   "65535",
+	}
+}
+
+func firewallRuleKubeApiServer(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "Kubernetes API Server",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "6443",
+		EndPort:   "6443",
+	}
+}
+
+func firewallRuleKubeletApi(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "Kubelet API",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "10250",
+		EndPort:   "10250",
+	}
+}
+
+func firewallRuleFlannel_VXLAN(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "Required only for Flannel VXLAN",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "8472",
+		EndPort:   "8472",
+	}
+}
+
+func firewallRuleKubeProxy(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "kube-proxy",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "10256",
+		EndPort:   "10256",
+	}
+}
+
+func firewallRuleNodePort(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "NodePort Services",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "30000",
+		EndPort:   "35000",
+	}
+}
+
+func firewallRuleEtcd(cidr string) FirewallRule {
+	return FirewallRule{
+		Description: "For HA with external etcd",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "2379",
+		EndPort:   "2380",
+	}
+}
+
+func firewallRuleNodePortWorkerNodes(cidr string) FirewallRule {
+	rule := firewallRuleNodePort(cidr)
+	rule.Description = "NodePort Services for kubeadm"
+	rule.EndPort = "32767"
+
+	return rule
+}
+
+func FirewallForControlplane_BASE(cidr string, distro consts.KsctlKubernetes) []FirewallRule {
+
+	rules := []FirewallRule{
+		firewallRuleKubeApiServer(cidr),
+		firewallRuleKubeletApi(cidr),
+		firewallRuleNodePort(cidr),
+		firewallRuleSSH(),
+		firewallRuleOutBoundAllUDP(),
+		firewallRuleOutBoundAllTCP(),
+	}
+
+	if distro == consts.K8sK3s {
+		rules = append(rules, firewallRuleFlannel_VXLAN(cidr))
+	}
+
+	return rules
+}
+
+func FirewallForWorkerplane_BASE(cidr string, distro consts.KsctlKubernetes) []FirewallRule {
+
+	rules := []FirewallRule{
+		firewallRuleKubeletApi(cidr),
+		firewallRuleSSH(),
+		firewallRuleOutBoundAllUDP(),
+		firewallRuleOutBoundAllTCP(),
+	}
+
+	switch distro {
+	case consts.K8sK3s:
+		rules = append(rules, firewallRuleFlannel_VXLAN(cidr))
+	case consts.K8sKubeadm:
+		rules = append(rules,
+			firewallRuleKubeProxy(cidr),
+			firewallRuleNodePortWorkerNodes(cidr),
+		)
+	}
+
+	return rules
+}
+
+func FirewallForLoadBalancer_BASE() []FirewallRule {
+	return []FirewallRule{
+		firewallRuleKubeApiServer("0.0.0.0/0"),
+		firewallRuleNodePort("0.0.0.0/0"),
+		firewallRuleSSH(),
+		firewallRuleOutBoundAllUDP(),
+		firewallRuleOutBoundAllTCP(),
+	}
+}
+
+func FirewallForDataStore_BASE(cidr string) []FirewallRule {
+	return []FirewallRule{
+		firewallRuleEtcd(cidr),
+		firewallRuleSSH(),
+		firewallRuleOutBoundAllUDP(),
+		firewallRuleOutBoundAllTCP(),
+	}
+}

--- a/pkg/helpers/firewall_rules.go
+++ b/pkg/helpers/firewall_rules.go
@@ -114,7 +114,7 @@ func firewallRuleKubeProxy(cidr string) FirewallRule {
 	}
 }
 
-func firewallRuleNodePort(cidr string) FirewallRule {
+func firewallRuleNodePort() FirewallRule {
 	return FirewallRule{
 		Name:        "kubernetes_nodeport",
 		Description: "NodePort Services",
@@ -122,9 +122,9 @@ func firewallRuleNodePort(cidr string) FirewallRule {
 		Direction:   consts.FirewallActionIngress,
 		Action:      consts.FirewallActionAllow,
 
-		Cidr:      cidr,
+		Cidr:      "0.0.0.0/0",
 		StartPort: "30000",
-		EndPort:   "35000",
+		EndPort:   "32767",
 	}
 }
 
@@ -142,20 +142,12 @@ func firewallRuleEtcd(cidr string) FirewallRule {
 	}
 }
 
-func firewallRuleNodePortWorkerNodes(cidr string) FirewallRule {
-	rule := firewallRuleNodePort(cidr)
-	rule.Description = "NodePort Services for kubeadm"
-	rule.EndPort = "32767"
-
-	return rule
-}
-
 func FirewallForControlplane_BASE(cidr string, distro consts.KsctlKubernetes) []FirewallRule {
 
 	rules := []FirewallRule{
 		firewallRuleKubeApiServer(cidr),
 		firewallRuleKubeletApi(cidr),
-		firewallRuleNodePort(cidr),
+		firewallRuleNodePort(),
 		firewallRuleSSH(),
 		firewallRuleOutBoundAllUDP(),
 		firewallRuleOutBoundAllTCP(),
@@ -173,6 +165,7 @@ func FirewallForWorkerplane_BASE(cidr string, distro consts.KsctlKubernetes) []F
 	rules := []FirewallRule{
 		firewallRuleKubeletApi(cidr),
 		firewallRuleSSH(),
+		firewallRuleNodePort(),
 		firewallRuleOutBoundAllUDP(),
 		firewallRuleOutBoundAllTCP(),
 	}
@@ -183,7 +176,6 @@ func FirewallForWorkerplane_BASE(cidr string, distro consts.KsctlKubernetes) []F
 	case consts.K8sKubeadm:
 		rules = append(rules,
 			firewallRuleKubeProxy(cidr),
-			firewallRuleNodePortWorkerNodes(cidr),
 		)
 	}
 
@@ -193,7 +185,6 @@ func FirewallForWorkerplane_BASE(cidr string, distro consts.KsctlKubernetes) []F
 func FirewallForLoadBalancer_BASE() []FirewallRule {
 	return []FirewallRule{
 		firewallRuleKubeApiServer("0.0.0.0/0"),
-		firewallRuleNodePort("0.0.0.0/0"),
 		firewallRuleSSH(),
 		firewallRuleOutBoundAllUDP(),
 		firewallRuleOutBoundAllTCP(),

--- a/pkg/helpers/ssh.go
+++ b/pkg/helpers/ssh.go
@@ -120,21 +120,14 @@ func ExecuteScript(log resources.LoggerFactory, conn *ssh.Client, script string)
 			return
 		}
 
-		if err != nil {
-			errV := ssh.ExitMissingError{}
-			scriptErrV := ssh.ExitError{}
+		missingStatusErr := ssh.ExitMissingError{}
 
-			fmt.Printf("Error checks err: %#v, errV: %#v, scriptErrV: %#v\n", err, errV, scriptErrV)
-			fmt.Printf("Error Erro() err: %#v, errV: %#v, scriptErrV: %#v\n", err.Error(), errV.Error(), scriptErrV.Error())
-
-			switch err.Error() {
-			case errV.Error():
-				log.Warn("Missing error code but exited. Reason can be session comm failure. Retrying!")
-				netRetry++
-			default:
-				// case scriptErrV.Error():
-				return // if any error which is not same as ExitMissingError
-			}
+		switch err.Error() {
+		case missingStatusErr.Error():
+			log.Warn("Missing error code but exited. Reason can be session comm failure. Retrying!")
+			netRetry++
+		default:
+			return // if any error which is not same as ExitMissingError
 		}
 	}
 

--- a/pkg/helpers/utils_test.go
+++ b/pkg/helpers/utils_test.go
@@ -59,6 +59,13 @@ func TestConsts(t *testing.T) {
 	assert.Equal(t, string(consts.CNIKubenet), "kubenet")
 	assert.Equal(t, string(consts.LinuxSh), "/bin/sh")
 	assert.Equal(t, string(consts.LinuxBash), "/bin/bash")
+
+	assert.Equal(t, int(consts.FirewallActionAllow), 0)
+	assert.Equal(t, int(consts.FirewallActionDeny), 1)
+	assert.Equal(t, int(consts.FirewallActionIngress), 2)
+	assert.Equal(t, int(consts.FirewallActionEgress), 3)
+	assert.Equal(t, int(consts.FirewallActionTCP), 4)
+	assert.Equal(t, int(consts.FirewallActionUDP), 5)
 }
 
 func TestGenerateCerts(t *testing.T) {
@@ -254,5 +261,235 @@ func TestScriptCollection(t *testing.T) {
 
 		assert.DeepEqual(t, v, expected)
 		assert.Equal(t, scripts.currIdx, 1, "the index must increment")
+	})
+}
+
+func TestFirewallRules(t *testing.T) {
+
+	cidr := "x.y.z.a/b"
+	expectedEtcd := FirewallRule{
+		Name:        "etcd",
+		Description: "For HA with external etcd",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "2379",
+		EndPort:   "2380",
+	}
+
+	expectedSSH := FirewallRule{
+		Name:        "ksctl_ssh",
+		Description: "SSH port for ksctl to work",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "22",
+		EndPort:   "22",
+	}
+	expectedUdp := FirewallRule{
+		Name:        "all_udp_outgoing",
+		Description: "enable all the UDP outgoing traffic",
+		Protocol:    consts.FirewallActionUDP,
+		Direction:   consts.FirewallActionEgress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "1",
+		EndPort:   "65535",
+	}
+	expectedTcp := FirewallRule{
+		Name:        "all_tcp_outgoing",
+		Description: "enable all the TCP outgoing traffic",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionEgress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "1",
+		EndPort:   "65535",
+	}
+	expectedK8sApiServer := FirewallRule{
+		Name:        "kubernetes_api_server",
+		Description: "Kubernetes API Server",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "6443",
+		EndPort:   "6443",
+	}
+	expectedKubeletApi := FirewallRule{
+		Name:        "kubelet_api",
+		Description: "Kubelet API",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "10250",
+		EndPort:   "10250",
+	}
+	expectedFlannelVXLan := FirewallRule{
+		Name:        "cni_flannel_vxlan",
+		Description: "Required only for Flannel VXLAN",
+		Protocol:    consts.FirewallActionUDP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "8472",
+		EndPort:   "8472",
+	}
+	expectedKubeProxy := FirewallRule{
+		Name:        "kubernetes_kube_proxy",
+		Description: "kube-proxy",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      cidr,
+		StartPort: "10256",
+		EndPort:   "10256",
+	}
+	expectedNodePort := FirewallRule{
+		Name:        "kubernetes_nodeport",
+		Description: "NodePort Services",
+		Protocol:    consts.FirewallActionTCP,
+		Direction:   consts.FirewallActionIngress,
+		Action:      consts.FirewallActionAllow,
+
+		Cidr:      "0.0.0.0/0",
+		StartPort: "30000",
+		EndPort:   "32767",
+	}
+
+	t.Run("ssh rule", func(t *testing.T) {
+		got := firewallRuleSSH()
+		assert.Equal(t, got, expectedSSH)
+	})
+	t.Run("allow all udp", func(t *testing.T) {
+		got := firewallRuleOutBoundAllUDP()
+		assert.Equal(t, got, expectedUdp)
+	})
+	t.Run("allow all tcp", func(t *testing.T) {
+		got := firewallRuleOutBoundAllTCP()
+		assert.Equal(t, got, expectedTcp)
+	})
+
+	t.Run("kube api server", func(t *testing.T) {
+		got := firewallRuleKubeApiServer(cidr)
+		assert.Equal(t, got, expectedK8sApiServer)
+	})
+
+	t.Run("kubelet api", func(t *testing.T) {
+		got := firewallRuleKubeletApi(cidr)
+		assert.Equal(t, got, expectedKubeletApi)
+	})
+
+	t.Run("cni flannel vxlan", func(t *testing.T) {
+		got := firewallRuleFlannel_VXLAN(cidr)
+		assert.Equal(t, got, expectedFlannelVXLan)
+	})
+
+	t.Run("kubernetes kube proxy", func(t *testing.T) {
+		got := firewallRuleKubeProxy(cidr)
+		assert.Equal(t, got, expectedKubeProxy)
+	})
+
+	t.Run("kubernetes nodeport", func(t *testing.T) {
+		got := firewallRuleNodePort()
+		assert.Equal(t, got, expectedNodePort)
+	})
+
+	t.Run("etcd", func(t *testing.T) {
+		got := firewallRuleEtcd(cidr)
+		assert.Equal(t, got, expectedEtcd)
+	})
+
+	t.Run("firewallRule for ControlPlane", func(t *testing.T) {
+		assert.DeepEqual(t,
+			FirewallForControlplane_BASE(
+				cidr, consts.K8sK3s),
+			[]FirewallRule{
+				expectedK8sApiServer,
+				expectedKubeletApi,
+				expectedNodePort,
+				expectedSSH,
+				expectedUdp,
+				expectedTcp,
+				expectedFlannelVXLan,
+			})
+		assert.DeepEqual(t,
+			FirewallForControlplane_BASE(
+				cidr, consts.K8sKubeadm),
+			[]FirewallRule{
+				expectedK8sApiServer,
+				expectedKubeletApi,
+				expectedNodePort,
+				expectedSSH,
+				expectedUdp,
+				expectedTcp,
+			})
+	})
+
+	t.Run("firewallRule for WorkerPlane", func(t *testing.T) {
+		assert.DeepEqual(t,
+			FirewallForWorkerplane_BASE(
+				cidr, consts.K8sK3s),
+			[]FirewallRule{
+				expectedKubeletApi,
+				expectedSSH,
+				expectedNodePort,
+				expectedUdp,
+				expectedTcp,
+				expectedFlannelVXLan,
+			})
+		assert.DeepEqual(t,
+			FirewallForWorkerplane_BASE(
+				cidr, consts.K8sKubeadm),
+			[]FirewallRule{
+				expectedKubeletApi,
+				expectedSSH,
+				expectedNodePort,
+				expectedUdp,
+				expectedTcp,
+				expectedKubeProxy,
+			})
+	})
+	t.Run("firewallRule for LoadBalancer", func(t *testing.T) {
+		assert.DeepEqual(t,
+			FirewallForLoadBalancer_BASE(),
+			[]FirewallRule{
+				{
+					Name:        "kubernetes_api_server",
+					Description: "Kubernetes API Server",
+					Protocol:    consts.FirewallActionTCP,
+					Direction:   consts.FirewallActionIngress,
+					Action:      consts.FirewallActionAllow,
+
+					Cidr:      "0.0.0.0/0",
+					StartPort: "6443",
+					EndPort:   "6443",
+				},
+
+				expectedSSH,
+				expectedUdp,
+				expectedTcp,
+			})
+	})
+	t.Run("firewallRule for DataStore", func(t *testing.T) {
+		assert.DeepEqual(t,
+			FirewallForDataStore_BASE(cidr),
+			[]FirewallRule{
+				expectedEtcd,
+				expectedSSH,
+				expectedUdp,
+				expectedTcp,
+			})
 	})
 }

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -55,6 +55,13 @@ cd cloudproviders/azure/
 GOTEST_PALETTE="red,yellow,green" $EXEC . -v && cd -
 
 echo "--------------------------------------------"
+echo "|   Testing (internal/cloudproviders/aws)"
+echo "--------------------------------------------"
+
+cd cloudproviders/aws/
+GOTEST_PALETTE="red,yellow,green" $EXEC . -v && cd -
+
+echo "--------------------------------------------"
 echo "|   Testing (internal/storage/local)"
 echo "--------------------------------------------"
 

--- a/scripts/test-aws.ps1
+++ b/scripts/test-aws.ps1
@@ -1,0 +1,18 @@
+#Requires -Version 5
+
+$erroractionpreference = 'stop' # quit if anything goes wrong
+
+if (($PSVersionTable.PSVersion.Major) -lt 5) {
+  Write-Output "PowerShell 5 or later is required to run Datree."
+  Write-Output "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+  break
+}
+
+Set-Location .\..\internal\
+
+Write-Output "--------------------------------------------"
+Write-Output "|   Testing (internal/cloudproviders/aws)"
+Write-Output "--------------------------------------------"
+
+Set-Location cloudproviders\aws
+go test . -v && Set-Location -

--- a/scripts/test-aws.sh
+++ b/scripts/test-aws.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+EXEC=$1
+cd ../internal || exit 1
+
+echo "--------------------------------------------"
+echo "|   Testing (internal/cloudproviders/aws)"
+echo "--------------------------------------------"
+
+cd cloudproviders/aws/
+GOTEST_PALETTE="red,yellow,green" $EXEC . -v && cd -
+

--- a/test/e2e/aws/create-ha-kubeadm.json
+++ b/test/e2e/aws/create-ha-kubeadm.json
@@ -12,6 +12,5 @@
   "node_type_loadbalancer": "t2.micro",
   "desired_no_of_workerplane_nodes": 1,
   "desired_no_of_controlplane_nodes": 3,
-  "desired_no_of_datastore_nodes": 3,
-  "cni_plugin": "cilium"
+  "desired_no_of_datastore_nodes": 3
 }

--- a/test/e2e/azure/create-ha-kubeadm.json
+++ b/test/e2e/azure/create-ha-kubeadm.json
@@ -12,6 +12,5 @@
 	"node_type_loadbalancer": "Standard_F2s",
 	"desired_no_of_workerplane_nodes": 1,
 	"desired_no_of_controlplane_nodes": 3,
-	"desired_no_of_datastore_nodes": 3,
-	"cni_plugin": "cilium"
+	"desired_no_of_datastore_nodes": 3
 }

--- a/test/e2e/civo/create-ha-kubeadm.json
+++ b/test/e2e/civo/create-ha-kubeadm.json
@@ -12,6 +12,5 @@
 	"node_type_loadbalancer": "g3.small",
 	"desired_no_of_workerplane_nodes": 1,
 	"desired_no_of_controlplane_nodes": 3,
-	"desired_no_of_datastore_nodes": 3,
-	"cni_plugin": "cilium"
+	"desired_no_of_datastore_nodes": 3
 }

--- a/test/e2e/local/create.json
+++ b/test/e2e/local/create.json
@@ -5,5 +5,5 @@
 	"cloud_provider": "local",
 	"storage_type": "local",
 	"desired_no_of_managed_nodes": 2,
-	"cni_plugin": "cilium"
+	"cni_plugin": "flannel"
 }

--- a/test/e2e/local/create.json
+++ b/test/e2e/local/create.json
@@ -4,6 +4,5 @@
 	"ha_cluster": false,
 	"cloud_provider": "local",
 	"storage_type": "local",
-	"desired_no_of_managed_nodes": 2,
-	"cni_plugin": "flannel"
+	"desired_no_of_managed_nodes": 2
 }


### PR DESCRIPTION
# Tasks description

- It adds firewall rules to the existing process of creation of self-managed HA clusters.(Azure, Aws, Civo)
- It Also improves the ssh retries for kubeadm and k3s bootstrap process
- fixes major security bugs for the bootstrap Ips for loadbalancers
- Loadbalancer is now using 1.28-lts haproxy

## Issues
### Completed Issue(s)
- Fixes #87

Expectation from this PR, all ports and addresses are secured
Here is a output of nodePort working from Controlplane and Workerplane publicIP itself

# Solution

### Sub-Tasks
- [x] civo (k3s)
- [x] civo (kubeadm)
- [x] azure (k3s)
- [x] azure (kubeadm)
- [x] aws (k3s)
- [x] aws (kubeadm)

# Note to reviewers

### Updates to docs
- Added default cni for kubeadm (flannel)
- update the warning in docs about **firewall rule not there**
- Document about the firewall rules


- [x] Ran Tests locally
- [x] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
