### PR TITLE
fix: permission of user issue in e2e

### DIFF
--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -31,6 +31,7 @@ jobs:
               - 'internal/k8sdistros/kubeadm/*'
               - 'internal/k8sdistros/*'
               - 'internal/storage/**'
+              - 'test/gh-runner/**'
               - 'pkg/helpers/**'
               - 'pkg/logger/**'
               - 'test/e2e/*'

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -31,6 +31,7 @@ jobs:
               - 'internal/k8sdistros/k3s/*'
               - 'internal/k8sdistros/kubeadm/*'
               - 'internal/k8sdistros/*'
+              - 'test/gh-runner/**'
               - 'internal/storage/**'
               - 'pkg/helpers/**'
               - 'pkg/logger/**'

--- a/.github/workflows/e2e-civo.yml
+++ b/.github/workflows/e2e-civo.yml
@@ -31,6 +31,7 @@ jobs:
               - 'internal/k8sdistros/*'
               - 'internal/storage/**'
               - 'pkg/helpers/**'
+              - 'test/gh-runner/**'
               - 'pkg/logger/**'
               - 'test/e2e/*'
               - 'test/e2e/civo/*'

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -28,6 +28,7 @@ jobs:
               - 'pkg/helpers/**'
               - 'pkg/logger/**'
               - 'test/e2e/*'
+              - 'test/gh-runner/**'
               - 'test/e2e/local/*'
               - 'go.mod'
               - 'go.sum'

--- a/test/gh-runner/configure/destroy.yml
+++ b/test/gh-runner/configure/destroy.yml
@@ -26,8 +26,7 @@
     - name: uninstall the service
       when: credentials_exist.stat.exists == true
       shell: |
-        cd /home/runner/actions-runner
-        sudo ./svc.sh uninstall
+        sudo su - runner -c "cd ~/actions-runner && sudo ./svc.sh uninstall"
 
     - name: command to add the runner to github
       when: credentials_exist.stat.exists == true

--- a/test/gh-runner/configure/gh-runner.yml
+++ b/test/gh-runner/configure/gh-runner.yml
@@ -6,6 +6,14 @@
     shell: '/bin/bash'
     state: present
 
+- name: give runner sudo nopasswd previliges
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/runner
+    content: 'runner ALL=(ALL) NOPASSWD: ALL'
+    owner: root
+    group: root
+    mode: '0440'
+
 - name: Fetch JSON data using curl
   ansible.builtin.shell: curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name'
   register: curl_output
@@ -63,15 +71,12 @@
 - name: start the service
   when: credentials_exist.stat.exists == false
   ansible.builtin.shell: |
-    cd /home/runner/actions-runner
-    sudo ./svc.sh install
-    sudo ./svc.sh start
+    sudo su - runner -c "cd ~/actions-runner && sudo ./svc.sh install && sudo ./svc.sh start"
 
 - name: status of the service
   register: gh_runner_svc_stat
   ansible.builtin.shell: |
-    cd /home/runner/actions-runner
-    sudo ./svc.sh status
+    sudo su - runner -c "cd ~/actions-runner && sudo ./svc.sh status"
 
 - name: display the status
   ansible.builtin.debug:


### PR DESCRIPTION
# Tasks description

When the gh runs on the e2e servers it uses the /root as home directory instead of /home/runner
due to which the e2e tests are failing

## Issues
### Completed Issue(s)
- #9999

### Related Issue(s)
- #9999


# Solution

### Sub-Tasks
- [ ] milestones or sub-task which needs to be coverted

# Note to reviewers

- [ ] Ran Tests locally
- [ ] Checked [Contribution's guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)
