### PR TITLE
Improved component version handling

### DIFF
--- a/internal/kubernetes/components/argocd.go
+++ b/internal/kubernetes/components/argocd.go
@@ -36,16 +36,12 @@ func setArgocdComponentOverridings(p metadata.ComponentOverrides) (
 	url string,
 	postInstall string,
 ) {
-	version = "stable"
 	url = ""
 	postInstall = ""
 
 	_version, _noUI, _namespaceInstall := getArgocdComponentOverridings(p)
-	if _version != nil {
-		if *_version != "latest" {
-			version = *_version
-		}
-	}
+
+	version = getVersionIfItsNotNilAndLatest(_version, "stable")
 
 	defaultVals := func() {
 		url = fmt.Sprintf("https://raw.githubusercontent.com/argoproj/argo-cd/%s/manifests/install.yaml", version)

--- a/internal/kubernetes/components/argocd_test.go
+++ b/internal/kubernetes/components/argocd_test.go
@@ -8,17 +8,20 @@ import (
 )
 
 func TestArgocdComponentOverridingsWithNilParams(t *testing.T) {
-	version, url, postInstall := setArgocdComponentOverridings(nil)
+	version, url, postInstall, ns := setArgocdComponentOverridings(nil)
 	assert.Equal(t, "stable", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
 func TestArgocdComponentOverridingsWithEmptyParams(t *testing.T) {
 	params := metadata.ComponentOverrides{
-		"version": "latest",
+		"version":   "latest",
+		"namespace": "nice",
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
+	assert.Equal(t, "nice", ns)
 	assert.Equal(t, "stable", version)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
@@ -28,8 +31,9 @@ func TestArgocdComponentOverridingsWithVersionOnly(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"version": "v1.0.0",
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
@@ -38,8 +42,9 @@ func TestArgocdComponentOverridingsWithNoUITrue(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"noUI": true,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
@@ -48,8 +53,9 @@ func TestArgocdComponentOverridingsWithNoUIFalse(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"noUI": false,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml"}, url)
 	assert.Contains(t, postInstall, "https://argo-cd.readthedocs.io/en/stable/operator-manual/core/")
 }
@@ -58,8 +64,9 @@ func TestArgocdComponentOverridingsWithNamespaceInstallTrue(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"namespaceInstall": true,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t,
 		[]string{
 			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/crds/application-crd.yaml",
@@ -74,8 +81,9 @@ func TestArgocdComponentOverridingsWithNamespaceInstallFalse(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"namespaceInstall": false,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
@@ -85,8 +93,9 @@ func TestArgocdComponentOverridingsWithVersionAndNoUI(t *testing.T) {
 		"version": "v1.0.0",
 		"noUI":    true,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
@@ -96,8 +105,9 @@ func TestArgocdComponentOverridingsWithVersionAndNamespaceInstall(t *testing.T) 
 		"version":          "v1.0.0",
 		"namespaceInstall": true,
 	}
-	version, url, postInstall := setArgocdComponentOverridings(params)
+	version, url, postInstall, ns := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
+	assert.Equal(t, "argocd", ns)
 	assert.Equal(t,
 		[]string{
 			"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/crds/application-crd.yaml",

--- a/internal/kubernetes/components/argocd_test.go
+++ b/internal/kubernetes/components/argocd_test.go
@@ -1,15 +1,16 @@
 package components
 
 import (
+	"testing"
+
 	"github.com/ksctl/ksctl/internal/kubernetes/metadata"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestArgocdComponentOverridingsWithNilParams(t *testing.T) {
 	version, url, postInstall := setArgocdComponentOverridings(nil)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -19,7 +20,7 @@ func TestArgocdComponentOverridingsWithEmptyParams(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -29,7 +30,7 @@ func TestArgocdComponentOverridingsWithVersionOnly(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -39,7 +40,7 @@ func TestArgocdComponentOverridingsWithNoUITrue(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -49,7 +50,7 @@ func TestArgocdComponentOverridingsWithNoUIFalse(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml"}, url)
 	assert.Contains(t, postInstall, "https://argo-cd.readthedocs.io/en/stable/operator-manual/core/")
 }
 
@@ -59,7 +60,13 @@ func TestArgocdComponentOverridingsWithNamespaceInstallTrue(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/namespace-install.yaml", url)
+	assert.Equal(t,
+		[]string{
+			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/crds/application-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/crds/appproject-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/crds/applicationset-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/namespace-install.yaml",
+		}, url)
 	assert.Contains(t, postInstall, "https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#non-high-availability")
 }
 
@@ -69,7 +76,7 @@ func TestArgocdComponentOverridingsWithNamespaceInstallFalse(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "stable", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -80,7 +87,7 @@ func TestArgocdComponentOverridingsWithVersionAndNoUI(t *testing.T) {
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml", url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argocd")
 }
 
@@ -91,6 +98,12 @@ func TestArgocdComponentOverridingsWithVersionAndNamespaceInstall(t *testing.T) 
 	}
 	version, url, postInstall := setArgocdComponentOverridings(params)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/namespace-install.yaml", url)
+	assert.Equal(t,
+		[]string{
+			"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/crds/application-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/crds/appproject-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/crds/applicationset-crd.yaml",
+			"https://raw.githubusercontent.com/argoproj/argo-cd/v1.0.0/manifests/namespace-install.yaml",
+		}, url)
 	assert.Contains(t, postInstall, "https://argo-cd.readthedocs.io/en/v1.0.0/operator-manual/installation/#non-high-availability")
 }

--- a/internal/kubernetes/components/argorollouts.go
+++ b/internal/kubernetes/components/argorollouts.go
@@ -39,17 +39,15 @@ func setArgorolloutsComponentOverridings(params metadata.ComponentOverrides) (
 	if err != nil {
 		return
 	}
-	version = releases[0]
+
 	url = ""
 	postInstall = ""
 
 	_version, _namespaceInstall := getArgorolloutsComponentOverridings(params)
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	defaultVals := func() {
-		url = fmt.Sprintf("https://github.com/argoproj/argo-rollouts/releases/%s/download/install.yaml", version)
+		url = fmt.Sprintf("https://github.com/argoproj/argo-rollouts/releases/download/%s/install.yaml", version)
 		postInstall = `
 Commands to execute to access Argo-Rollouts
 $ kubectl argo rollouts version
@@ -60,9 +58,10 @@ and open http://localhost:3100/rollouts
 
 	if _namespaceInstall != nil {
 		if *_namespaceInstall {
-			url = fmt.Sprintf("https://raw.githubusercontent.com/argoproj/argo-cd/%s/manifests/namespace-install.yaml", version)
+			// TODO: need to install the crd as well
+			url = fmt.Sprintf("https://raw.githubusercontent.com/argoproj/argo-rollouts/%s/manifests/namespace-install.yaml", version)
 			postInstall = fmt.Sprintf(`
-https://argo-cd.readthedocs.io/en/%s/operator-manual/installation/#non-high-availability
+https://argo-rollouts.readthedocs.io/en/%v/installation/#controller-installation
 `, version)
 
 		} else {

--- a/internal/kubernetes/components/argorollouts_test.go
+++ b/internal/kubernetes/components/argorollouts_test.go
@@ -14,7 +14,7 @@ func TestArgorolloutsComponentOverridingsWithVersionOnly(t *testing.T) {
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.0.0/install.yaml", url)
+	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.0.0/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }
 
@@ -25,7 +25,14 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallTrueOnly(t *testing
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/namespace-install.yaml", url)
+	assert.Equal(t, []string{
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml",
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/experiment-crd.yaml",
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/analysis-run-crd.yaml",
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/analysis-template-crd.yaml",
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/cluster-analysis-template-crd.yaml",
+		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/namespace-install.yaml",
+	}, url)
 	assert.Contains(t, postInstall, "https://argo-rollouts.readthedocs.io/en/v1.7.2/installation/#controller-installation")
 }
 
@@ -36,7 +43,7 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallFalseOnly(t *testin
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml", url)
+	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }
 
@@ -45,6 +52,6 @@ func TestArgorolloutsComponentOverridingsWithEmptyParams(t *testing.T) {
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml", url)
+	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }

--- a/internal/kubernetes/components/argorollouts_test.go
+++ b/internal/kubernetes/components/argorollouts_test.go
@@ -11,8 +11,9 @@ func TestArgorolloutsComponentOverridingsWithVersionOnly(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"version": "v1.0.0",
 	}
-	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
+	version, url, postInstall, ns, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
+	assert.Equal(t, "argo-rollouts", ns)
 	assert.Equal(t, "v1.0.0", version)
 	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.0.0/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
@@ -22,8 +23,9 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallTrueOnly(t *testing
 	params := metadata.ComponentOverrides{
 		"namespaceInstall": true,
 	}
-	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
+	version, url, postInstall, ns, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
+	assert.Equal(t, "argo-rollouts", ns)
 	assert.Equal(t, "v1.7.2", version)
 	assert.Equal(t, []string{
 		"https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml",
@@ -39,9 +41,11 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallTrueOnly(t *testing
 func TestArgorolloutsComponentOverridingsWithNamespaceInstallFalseOnly(t *testing.T) {
 	params := metadata.ComponentOverrides{
 		"namespaceInstall": false,
+		"namespace":        "nice",
 	}
-	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
+	version, url, postInstall, ns, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
+	assert.Equal(t, "nice", ns)
 	assert.Equal(t, "v1.7.2", version)
 	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
@@ -49,8 +53,9 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallFalseOnly(t *testin
 
 func TestArgorolloutsComponentOverridingsWithEmptyParams(t *testing.T) {
 	params := metadata.ComponentOverrides{}
-	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
+	version, url, postInstall, ns, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
+	assert.Equal(t, "argo-rollouts", ns)
 	assert.Equal(t, "v1.7.2", version)
 	assert.Equal(t, []string{"https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml"}, url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")

--- a/internal/kubernetes/components/argorollouts_test.go
+++ b/internal/kubernetes/components/argorollouts_test.go
@@ -14,7 +14,7 @@ func TestArgorolloutsComponentOverridingsWithVersionOnly(t *testing.T) {
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/v1.0.0/download/install.yaml", url)
+	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.0.0/install.yaml", url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }
 
@@ -25,8 +25,8 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallTrueOnly(t *testing
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-cd/v1.7.2/manifests/namespace-install.yaml", url)
-	assert.Contains(t, postInstall, "https://argo-cd.readthedocs.io/en/v1.7.2/operator-manual/installation/#non-high-availability")
+	assert.Equal(t, "https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/namespace-install.yaml", url)
+	assert.Contains(t, postInstall, "https://argo-rollouts.readthedocs.io/en/v1.7.2/installation/#controller-installation")
 }
 
 func TestArgorolloutsComponentOverridingsWithNamespaceInstallFalseOnly(t *testing.T) {
@@ -36,7 +36,7 @@ func TestArgorolloutsComponentOverridingsWithNamespaceInstallFalseOnly(t *testin
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/v1.7.2/download/install.yaml", url)
+	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml", url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }
 
@@ -45,6 +45,6 @@ func TestArgorolloutsComponentOverridingsWithEmptyParams(t *testing.T) {
 	version, url, postInstall, err := setArgorolloutsComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.7.2", version)
-	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/v1.7.2/download/install.yaml", url)
+	assert.Equal(t, "https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/install.yaml", url)
 	assert.Contains(t, postInstall, "Commands to execute to access Argo-Rollouts")
 }

--- a/internal/kubernetes/components/certmanager.go
+++ b/internal/kubernetes/components/certmanager.go
@@ -49,7 +49,6 @@ func setCertManagerComponentOverridings(params metadata.ComponentOverrides) (
 	if err != nil {
 		return "", nil, err
 	}
-	version = releases[0]
 
 	overridings = map[string]any{
 		"crds": map[string]any{
@@ -59,9 +58,7 @@ func setCertManagerComponentOverridings(params metadata.ComponentOverrides) (
 
 	_version, _gateway_apiEnable, _certmanagerChartOverridings := getCertManagerComponentOverridings(params)
 
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	if _certmanagerChartOverridings != nil {
 		utilities.CopySrcToDestPreservingDestVals(overridings, _certmanagerChartOverridings)

--- a/internal/kubernetes/components/cilium.go
+++ b/internal/kubernetes/components/cilium.go
@@ -40,14 +40,11 @@ func setCiliumComponentOverridings(p metadata.ComponentOverrides) (
 		return "", nil, err
 	}
 
-	version = releases[0]
 	ciliumChartOverridings = map[string]any{}
 
 	_version, _ciliumChartOverridings := getCiliumComponentOverridings(p)
 
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	if _ciliumChartOverridings != nil {
 		ciliumChartOverridings = _ciliumChartOverridings

--- a/internal/kubernetes/components/component_version.go
+++ b/internal/kubernetes/components/component_version.go
@@ -1,0 +1,11 @@
+package components
+
+func getVersionIfItsNotNilAndLatest(ver *string, defaultVer string) string {
+	if ver == nil {
+		return defaultVer
+	}
+	if *ver == "latest" {
+		return defaultVer
+	}
+	return *ver
+}

--- a/internal/kubernetes/components/components_test.go
+++ b/internal/kubernetes/components/components_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ksctl/ksctl/pkg/helpers/utilities"
 	"github.com/ksctl/ksctl/poller"
 )
 
@@ -44,4 +45,41 @@ func TestMain(m *testing.M) {
 		return vers, nil
 	})
 	m.Run()
+}
+
+func TestGetVersionIfItsNotNilAndLatest(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     *string
+		defaultVer  string
+		expectedVer string
+	}{
+		{
+			name:        "version is nil",
+			version:     nil,
+			defaultVer:  "v0.0.1",
+			expectedVer: "v0.0.1",
+		},
+		{
+			name:        "version is latest",
+			version:     utilities.Ptr("latest"),
+			defaultVer:  "v0.0.1",
+			expectedVer: "v0.0.1",
+		},
+		{
+			name:        "version is not latest",
+			version:     utilities.Ptr("v1.0.0"),
+			defaultVer:  "v0.0.1",
+			expectedVer: "v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualVer := getVersionIfItsNotNilAndLatest(tt.version, tt.defaultVer)
+			if actualVer != tt.expectedVer {
+				t.Errorf("expected version %s, got %s", tt.expectedVer, actualVer)
+			}
+		})
+	}
 }

--- a/internal/kubernetes/components/flannel.go
+++ b/internal/kubernetes/components/flannel.go
@@ -59,7 +59,7 @@ func FlannelStandardComponent(params metadata.ComponentOverrides) (metadata.Stac
 	return metadata.StackComponent{
 		HandlerType: metadata.ComponentTypeKubectl,
 		Kubectl: &metadata.KubectlHandler{
-			Url:             url,
+			Urls:            []string{url},
 			Version:         version,
 			CreateNamespace: false,
 			Metadata:        fmt.Sprintf("Flannel (Ver: %s) is a simple and easy way to configure a layer 3 network fabric designed for Kubernetes.", version),

--- a/internal/kubernetes/components/flannel.go
+++ b/internal/kubernetes/components/flannel.go
@@ -34,17 +34,15 @@ func setFlannelComponentOverridings(p metadata.ComponentOverrides) (
 	if err != nil {
 		return "", "", "", err
 	}
-	version = releases[0]
+
 	url = ""
 	postInstall = ""
 
 	_version := getFlannelComponentOverridings(p)
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	defaultVals := func() {
-		url = fmt.Sprintf("https://github.com/flannel-io/flannel/releases/%s/download/kube-flannel.yml", version)
+		url = fmt.Sprintf("https://github.com/flannel-io/flannel/releases/download/%s/kube-flannel.yml", version)
 		postInstall = "https://github.com/flannel-io/flannel"
 	}
 

--- a/internal/kubernetes/components/flannel_test.go
+++ b/internal/kubernetes/components/flannel_test.go
@@ -11,7 +11,7 @@ func TestFlannelComponentOverridingsWithNilParams(t *testing.T) {
 	version, url, postInstall, err := setFlannelComponentOverridings(nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "v0.25.5", version)
-	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/v0.25.5/download/kube-flannel.yml", url)
+	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/download/v0.25.5/kube-flannel.yml", url)
 	assert.Equal(t, "https://github.com/flannel-io/flannel", postInstall)
 }
 
@@ -20,7 +20,7 @@ func TestFlannelComponentOverridingsWithEmptyParams(t *testing.T) {
 	version, url, postInstall, err := setFlannelComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v0.25.5", version)
-	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/v0.25.5/download/kube-flannel.yml", url)
+	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/download/v0.25.5/kube-flannel.yml", url)
 	assert.Equal(t, "https://github.com/flannel-io/flannel", postInstall)
 }
 
@@ -31,6 +31,6 @@ func TestFlannelComponentOverridingsWithVersionOnly(t *testing.T) {
 	version, url, postInstall, err := setFlannelComponentOverridings(params)
 	assert.Nil(t, err)
 	assert.Equal(t, "v1.0.0", version)
-	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/v1.0.0/download/kube-flannel.yml", url)
+	assert.Equal(t, "https://github.com/flannel-io/flannel/releases/download/v1.0.0/kube-flannel.yml", url)
 	assert.Equal(t, "https://github.com/flannel-io/flannel", postInstall)
 }

--- a/internal/kubernetes/components/istio.go
+++ b/internal/kubernetes/components/istio.go
@@ -1,10 +1,11 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/ksctl/ksctl/internal/kubernetes/metadata"
 	"github.com/ksctl/ksctl/pkg/helpers/utilities"
 	"github.com/ksctl/ksctl/poller"
-	"strings"
 )
 
 func getIstioComponentOverridings(p metadata.ComponentOverrides) (version *string, helmBaseChartOverridings map[string]interface{}, helmIstiodChartOverridings map[string]interface{}) {
@@ -44,15 +45,13 @@ func setIsitoComponentOverridings(p metadata.ComponentOverrides) (
 	if err != nil {
 		return "", nil, nil, err
 	}
-	version = releases[0]
+
 	helmBaseChartOverridings = map[string]any{}
 	helmIstiodChartOverridings = map[string]any{}
 
 	_version, _helmBaseChartOverridings, _helmIstiodChartOverridings := getIstioComponentOverridings(p)
 
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	if _helmBaseChartOverridings != nil {
 		helmBaseChartOverridings = _helmBaseChartOverridings

--- a/internal/kubernetes/components/ksctlapplication.go
+++ b/internal/kubernetes/components/ksctlapplication.go
@@ -57,7 +57,7 @@ func KsctlApplicationComponent(params metadata.ComponentOverrides) metadata.Stac
 	return metadata.StackComponent{
 		HandlerType: metadata.ComponentTypeKubectl,
 		Kubectl: &metadata.KubectlHandler{
-			Url:             url,
+			Urls:            []string{url},
 			CreateNamespace: false,
 			Metadata:        fmt.Sprintf("Ksctl Application controller (Ver: %s)", version),
 			PostInstall:     postInstall,

--- a/internal/kubernetes/components/kubeprometheus.go
+++ b/internal/kubernetes/components/kubeprometheus.go
@@ -1,9 +1,10 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/ksctl/ksctl/internal/kubernetes/metadata"
 	"github.com/ksctl/ksctl/pkg/helpers/utilities"
-	"strings"
 )
 
 func getKubePrometheusComponentOverridings(p metadata.ComponentOverrides) (version *string, helmKubePromChartOverridings map[string]interface{}) {
@@ -32,13 +33,10 @@ func setKubePrometheusComponentOverridings(p metadata.ComponentOverrides) (
 	version string,
 	helmKubePromChartOverridings map[string]any,
 ) {
-	version = "latest"
 	helmKubePromChartOverridings = map[string]any{}
 
 	_version, _helmKubePromChartOverridings := getKubePrometheusComponentOverridings(p)
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, "latest")
 
 	if _helmKubePromChartOverridings != nil {
 		helmKubePromChartOverridings = _helmKubePromChartOverridings

--- a/internal/kubernetes/components/kwasm.go
+++ b/internal/kubernetes/components/kwasm.go
@@ -1,9 +1,10 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/ksctl/ksctl/internal/kubernetes/metadata"
 	"github.com/ksctl/ksctl/pkg/helpers/utilities"
-	"strings"
 )
 
 const kwasmOperatorChartOverridingsKey = "kwasmOperatorChartOverridings"
@@ -37,13 +38,10 @@ func setKwasmOperatorComponentOverridings(params metadata.ComponentOverrides) (
 	overridings map[string]any,
 	err error,
 ) {
-	version = "latest"
 
 	_version, _kwasmOperatorChartOverridings := getKwasmOperatorComponentOverridings(params)
 
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, "latest")
 
 	if _kwasmOperatorChartOverridings != nil {
 		overridings = utilities.DeepCopyMap(_kwasmOperatorChartOverridings)

--- a/internal/kubernetes/components/kwasm.go
+++ b/internal/kubernetes/components/kwasm.go
@@ -56,7 +56,7 @@ func KwasmWasmedgeComponent(params metadata.ComponentOverrides) (metadata.StackC
 		Kubectl: &metadata.KubectlHandler{
 			CreateNamespace: false,
 			Version:         "latest",
-			Url:             "https://raw.githubusercontent.com/ksctl/components/main/wasm/kwasm/runtimeclass.yml",
+			Urls:            []string{"https://raw.githubusercontent.com/ksctl/components/main/wasm/kwasm/runtimeclass.yml"},
 			Metadata:        "It applies the runtime class for kwasm for wasmedge",
 		},
 	}, nil

--- a/internal/kubernetes/components/kwasm_test.go
+++ b/internal/kubernetes/components/kwasm_test.go
@@ -38,7 +38,7 @@ func TestKwasmWasmedgeComponent(t *testing.T) {
 	assert.Equal(t, metadata.ComponentTypeKubectl, component.HandlerType)
 	assert.NotNil(t, component.Kubectl)
 	assert.Equal(t, "latest", component.Kubectl.Version)
-	assert.Equal(t, "https://raw.githubusercontent.com/ksctl/components/main/wasm/kwasm/runtimeclass.yml", component.Kubectl.Url)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/ksctl/components/main/wasm/kwasm/runtimeclass.yml"}, component.Kubectl.Urls)
 }
 
 func TestKwasmWithSpinKube(t *testing.T) {

--- a/internal/kubernetes/components/spinkube.go
+++ b/internal/kubernetes/components/spinkube.go
@@ -110,7 +110,7 @@ func spinkubeReturnHelper(version, url, postInstall string) (metadata.StackCompo
 	return metadata.StackComponent{
 		HandlerType: metadata.ComponentTypeKubectl,
 		Kubectl: &metadata.KubectlHandler{
-			Url:             url,
+			Urls:            []string{url},
 			Version:         version,
 			CreateNamespace: false,
 			Metadata:        fmt.Sprintf("KubeSpin (ver: %s) is an open source project that streamlines developing, deploying and operating WebAssembly workloads in Kubernetes - resulting in delivering smaller, more portable applications and incredible compute performance benefits", version),

--- a/internal/kubernetes/components/spinkube.go
+++ b/internal/kubernetes/components/spinkube.go
@@ -61,14 +61,11 @@ func setSpinkubeComponentOverridings(p metadata.ComponentOverrides, theThing str
 	if err != nil {
 		return
 	}
-	version = releases[0]
 	url = ""
 	postInstall = ""
 
 	_version := getSpinkubeComponentOverridings(p)
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	defaultVals := func() {
 		url = fmt.Sprintf("https://github.com/spinkube/spin-operator/releases/download/%s/%s", version, theThing)
@@ -178,15 +175,12 @@ func setSpinOperatorComponentOverridings(p metadata.ComponentOverrides) (
 	if err != nil {
 		return
 	}
-	version = releases[0]
 
 	helmOperatorChartOverridings = map[string]any{}
 
 	_version, _helmOperatorChartOverridings := getSpinkubeOperatorComponentOverridings(p)
 
-	if _version != nil {
-		version = *_version
-	}
+	version = getVersionIfItsNotNilAndLatest(_version, releases[0])
 
 	if _helmOperatorChartOverridings != nil {
 		helmOperatorChartOverridings = _helmOperatorChartOverridings

--- a/internal/kubernetes/metadata/types.go
+++ b/internal/kubernetes/metadata/types.go
@@ -14,8 +14,8 @@ type KubectlHandler struct {
 	CreateNamespace bool
 	Namespace       string
 
-	Version     string // how to get the version propogated?
-	Url         string
+	Version     string   // how to get the version propogated?
+	Urls        []string // make sure you traverse backwards to uninstall resources
 	PostInstall string
 	Metadata    string
 }

--- a/poller/real_test.go
+++ b/poller/real_test.go
@@ -3,9 +3,10 @@
 package poller_test
 
 import (
+	"testing"
+
 	"github.com/gookit/goutil/dump"
 	"github.com/ksctl/ksctl/poller"
-	"testing"
 )
 
 func TestMain(m *testing.M) {
@@ -16,7 +17,7 @@ func TestMain(m *testing.M) {
 func TestGithub(t *testing.T) {
 	obj := poller.GetSharedPoller()
 
-	r, err := obj.Get("ksctl", "cli")
+	r, err := obj.Get("flannel-io", "flannel")
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}


### PR DESCRIPTION
patched the url for the release based download of manifests

and correction of argo-rollouts manifest url for namespacescoped install
