### PR TITLE
fix: added error propogation from PanicHandler and Stale state of Bootstrap

### DIFF
--- a/pkg/bootstrap/handler/bootstrap.go
+++ b/pkg/bootstrap/handler/bootstrap.go
@@ -88,27 +88,15 @@ func (kc *Controller) setupInterfaces(
 		kc.p.Storage,
 	)
 
+	var bootstrapProvider consts.KsctlKubernetes
+
 	if kc.s.BootstrapProvider == consts.K8sK3s || kc.s.BootstrapProvider == consts.K8sKubeadm {
-		switch kc.s.BootstrapProvider {
-		case consts.K8sK3s:
-			kc.p.Bootstrap = k3sPkg.NewClient(
-				kc.ctx,
-				kc.l,
-				kc.p.Storage,
-				kc.s,
-			)
-		case consts.K8sKubeadm:
-			kc.p.Bootstrap = kubeadmPkg.NewClient(
-				kc.ctx,
-				kc.l,
-				kc.p.Storage,
-				kc.s,
-			)
-		}
-		return nil
+		bootstrapProvider = kc.s.BootstrapProvider
+	} else {
+		bootstrapProvider = kc.p.Metadata.K8sDistro
 	}
 
-	switch kc.p.Metadata.K8sDistro {
+	switch bootstrapProvider {
 	case consts.K8sK3s:
 		kc.p.Bootstrap = k3sPkg.NewClient(
 			kc.ctx,

--- a/pkg/bootstrap/handler/bootstrap.go
+++ b/pkg/bootstrap/handler/bootstrap.go
@@ -315,16 +315,15 @@ func (kc *Controller) InstallAdditionalTools(externalCNI bool) error {
 				break
 			}
 		}
-		_c := stack.KsctlApp{
-			StackName: _cni.Name,
-		}
+		_c := stack.KsctlApp{}
 
 		if _cni == nil {
 			kc.l.Print(kc.ctx, "CNI Plugin not found in addons list")
 
-			_c.StackName = "flannel"
+			_c.StackName = "cilium"
 			_c.Overrides = nil
 		} else {
+			_c.StackName = _cni.Name
 			if _cni.Config == nil {
 				_c.Overrides = nil
 			} else {

--- a/pkg/bootstrap/handler/k8s.go
+++ b/pkg/bootstrap/handler/k8s.go
@@ -16,7 +16,7 @@ package handler
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/ksctl/ksctl/v2/pkg/apps/stack"
 	"github.com/ksctl/ksctl/v2/pkg/bootstrap/handler/cni"
@@ -236,7 +236,7 @@ advisiable to use external storage solution
 
 	if _err := k.storageDriver.Write(state); _err != nil {
 		if errorInStack != nil {
-			return fmt.Errorf(errorInStack.Error() + " " + _err.Error())
+			return errors.Join(errorInStack, _err)
 		}
 		return _err
 	}

--- a/pkg/bootstrap/main.go
+++ b/pkg/bootstrap/main.go
@@ -16,11 +16,12 @@ package bootstrap
 
 import (
 	"context"
+	"sync"
+
 	"github.com/ksctl/ksctl/v2/pkg/certs"
 	"github.com/ksctl/ksctl/v2/pkg/provider"
 	"github.com/ksctl/ksctl/v2/pkg/statefile"
 	"github.com/ksctl/ksctl/v2/pkg/storage"
-	"sync"
 
 	"github.com/ksctl/ksctl/v2/pkg/logger"
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -28,6 +28,7 @@ const (
 	ErrInternal
 	ErrDuplicateRecords
 	ErrNoMatchingRecordsFound
+	ErrPanic
 
 	ErrInvalidOperation
 	ErrInvalidKsctlRole
@@ -79,6 +80,8 @@ func (e KsctlError) errorCodeToString() string {
 		return "TimeoutErr"
 	case ErrContextCancelled:
 		return "ContextCancelledErr"
+	case ErrPanic:
+		return "PanicErr"
 	case ErrSSHExec:
 		return "SSHExecErr"
 	case ErrKubeconfigOperations:
@@ -170,6 +173,10 @@ func IsNilCredentials(err error) bool {
 
 func IsTimeout(err error) bool {
 	return codeForError(err) == ErrTimeOut
+}
+
+func IsPanic(err error) bool {
+	return codeForError(err) == ErrPanic
 }
 
 func IsContextCancelled(err error) bool {

--- a/pkg/handler/addons/clustermanager/disable.go
+++ b/pkg/handler/addons/clustermanager/disable.go
@@ -15,12 +15,21 @@
 package clustermanager
 
 import (
+	"errors"
+
 	bootstrapHandler "github.com/ksctl/ksctl/v2/pkg/bootstrap/handler"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 )
 
-func (kc *Controller) Disable() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Disable() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	transferableInfraState, err := kc.helper()
 	if err != nil {

--- a/pkg/handler/addons/clustermanager/enable.go
+++ b/pkg/handler/addons/clustermanager/enable.go
@@ -15,12 +15,21 @@
 package clustermanager
 
 import (
+	"errors"
+
 	bootstrapHandler "github.com/ksctl/ksctl/v2/pkg/bootstrap/handler"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 )
 
-func (kc *Controller) Enable() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Enable() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	transferableInfraState, err := kc.helper()
 	if err != nil {

--- a/pkg/handler/cluster/common/creds.go
+++ b/pkg/handler/cluster/common/creds.go
@@ -15,14 +15,23 @@
 package common
 
 import (
+	"errors"
+
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	ksctlErrors "github.com/ksctl/ksctl/v2/pkg/errors"
 	"github.com/ksctl/ksctl/v2/pkg/provider/aws"
 	"github.com/ksctl/ksctl/v2/pkg/provider/azure"
 )
 
-func (kc *Controller) Credentials() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Credentials() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	var err error
 	switch kc.p.Metadata.Provider {

--- a/pkg/handler/cluster/common/info.go
+++ b/pkg/handler/cluster/common/info.go
@@ -15,6 +15,8 @@
 package common
 
 import (
+	"errors"
+
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	ksctlErrors "github.com/ksctl/ksctl/v2/pkg/errors"
 	"github.com/ksctl/ksctl/v2/pkg/logger"
@@ -171,8 +173,15 @@ func (kc *Controller) clusterDataHelper(operation logger.LogClusterDetail) ([]lo
 	return printerTable, err
 }
 
-func (kc *Controller) GetCluster() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) GetCluster() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	v, err := kc.clusterDataHelper(logger.LoggingGetClusters)
 	if err != nil {
@@ -186,8 +195,15 @@ func (kc *Controller) GetCluster() error {
 	return nil
 }
 
-func (kc *Controller) InfoCluster() (*logger.ClusterDataForLogging, error) {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) InfoCluster() (_ *logger.ClusterDataForLogging, errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	v, err := kc.clusterDataHelper(logger.LoggingInfoCluster)
 	if err != nil {
@@ -198,5 +214,5 @@ func (kc *Controller) InfoCluster() (*logger.ClusterDataForLogging, error) {
 
 	kc.l.Success(kc.ctx, "successfully cluster info")
 
-	return utilities.Ptr[logger.ClusterDataForLogging](v[0]), nil
+	return utilities.Ptr(v[0]), nil
 }

--- a/pkg/handler/cluster/common/switch.go
+++ b/pkg/handler/cluster/common/switch.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,8 +29,15 @@ import (
 	"github.com/ksctl/ksctl/v2/pkg/provider/local"
 )
 
-func (kc *Controller) Switch() (*string, error) {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Switch() (_ *string, errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if kc.b.IsLocalProvider(kc.p) {
 		kc.p.Metadata.Region = "LOCAL"

--- a/pkg/handler/cluster/controller/manager.go
+++ b/pkg/handler/cluster/controller/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ksctl/ksctl/v2/pkg/bootstrap"
 	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
+	"github.com/ksctl/ksctl/v2/pkg/errors"
 	"github.com/ksctl/ksctl/v2/pkg/logger"
 	"github.com/ksctl/ksctl/v2/pkg/provider"
 	"github.com/ksctl/ksctl/v2/pkg/storage"
@@ -80,10 +81,13 @@ func NewBaseController(ctx context.Context, l logger.Logger) *Controller {
 	return b
 }
 
-func (cc *Controller) PanicHandler(log logger.Logger) {
+func (cc *Controller) PanicHandler(log logger.Logger) error {
 	if r := recover(); r != nil {
 		log.Error("Failed to recover stack trace", "error", r)
 		log.Print(cc.ctx, "Controller Information", "context", cc.ctx)
 		debug.PrintStack()
+
+		return errors.WrapErrorf(errors.ErrPanic, "Panic Error: %v", r)
 	}
+	return nil
 }

--- a/pkg/handler/cluster/controller/manager.go
+++ b/pkg/handler/cluster/controller/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	"github.com/ksctl/ksctl/v2/pkg/errors"
+	ksctlErrors "github.com/ksctl/ksctl/v2/pkg/errors"
 	"github.com/ksctl/ksctl/v2/pkg/logger"
 	"github.com/ksctl/ksctl/v2/pkg/provider"
 	"github.com/ksctl/ksctl/v2/pkg/storage"
@@ -87,7 +88,7 @@ func (cc *Controller) PanicHandler(log logger.Logger) error {
 		log.Print(cc.ctx, "Controller Information", "context", cc.ctx)
 		debug.PrintStack()
 
-		return errors.WrapErrorf(errors.ErrPanic, "Panic Error: %v", r)
+		return errors.WrapErrorf(ksctlErrors.ErrPanic, "Panic Error: %v", r)
 	}
 	return nil
 }

--- a/pkg/handler/cluster/controller/manager.go
+++ b/pkg/handler/cluster/controller/manager.go
@@ -84,11 +84,7 @@ func NewBaseController(ctx context.Context, l logger.Logger) *Controller {
 
 func (cc *Controller) PanicHandler(log logger.Logger) error {
 	if r := recover(); r != nil {
-		log.Error("Failed to recover stack trace", "error", r)
-		log.Print(cc.ctx, "Controller Information", "context", cc.ctx)
-		debug.PrintStack()
-
-		return errors.WrapErrorf(ksctlErrors.ErrPanic, "Panic Error: %v", r)
+		return errors.WrapErrorf(ksctlErrors.ErrPanic, "Cause: {%v}\nTraceback\n%v", r, string(debug.Stack()))
 	}
 	return nil
 }

--- a/pkg/handler/cluster/managed/create.go
+++ b/pkg/handler/cluster/managed/create.go
@@ -15,14 +15,23 @@
 package managed
 
 import (
+	"errors"
+
 	bootstrapHandler "github.com/ksctl/ksctl/v2/pkg/bootstrap/handler"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	providerHandler "github.com/ksctl/ksctl/v2/pkg/provider/handler"
 	"github.com/ksctl/ksctl/v2/pkg/validation"
 )
 
-func (kc *Controller) Create() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Create() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if kc.b.IsLocalProvider(kc.p) {
 		kc.p.Metadata.Region = "LOCAL"

--- a/pkg/handler/cluster/managed/delete.go
+++ b/pkg/handler/cluster/managed/delete.go
@@ -15,12 +15,21 @@
 package managed
 
 import (
+	"errors"
+
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	providerHandler "github.com/ksctl/ksctl/v2/pkg/provider/handler"
 )
 
-func (kc *Controller) Delete() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Delete() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if kc.b.IsLocalProvider(kc.p) {
 		kc.p.Metadata.Region = "LOCAL"

--- a/pkg/handler/cluster/selfmanaged/create.go
+++ b/pkg/handler/cluster/selfmanaged/create.go
@@ -15,6 +15,8 @@
 package selfmanaged
 
 import (
+	"errors"
+
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	"github.com/ksctl/ksctl/v2/pkg/validation"
 
@@ -23,8 +25,15 @@ import (
 	providerHandler "github.com/ksctl/ksctl/v2/pkg/provider/handler"
 )
 
-func (kc *Controller) Create() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Create() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if err := kc.p.Storage.Setup(
 		kc.p.Metadata.Provider,

--- a/pkg/handler/cluster/selfmanaged/delete.go
+++ b/pkg/handler/cluster/selfmanaged/delete.go
@@ -15,13 +15,22 @@
 package selfmanaged
 
 import (
+	"errors"
+
 	bootstrapHandler "github.com/ksctl/ksctl/v2/pkg/bootstrap/handler"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	providerHandler "github.com/ksctl/ksctl/v2/pkg/provider/handler"
 )
 
-func (kc *Controller) Delete() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) Delete() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if err := kc.p.Storage.Setup(
 		kc.p.Metadata.Provider,

--- a/pkg/handler/cluster/selfmanaged/nodes.go
+++ b/pkg/handler/cluster/selfmanaged/nodes.go
@@ -15,6 +15,7 @@
 package selfmanaged
 
 import (
+	"errors"
 	"strings"
 
 	bootstrapHandler "github.com/ksctl/ksctl/v2/pkg/bootstrap/handler"
@@ -23,8 +24,15 @@ import (
 	providerHandler "github.com/ksctl/ksctl/v2/pkg/provider/handler"
 )
 
-func (kc *Controller) AddWorkerNodes() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) AddWorkerNodes() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if !kc.b.IsSelfManaged(kc.p) {
 		err := kc.l.NewError(kc.ctx, "this feature is only for selfmanaged clusters")
@@ -91,8 +99,15 @@ func (kc *Controller) AddWorkerNodes() error {
 	return nil
 }
 
-func (kc *Controller) DeleteWorkerNodes() error {
-	defer kc.b.PanicHandler(kc.l)
+func (kc *Controller) DeleteWorkerNodes() (errC error) {
+	defer func() {
+		if errC != nil {
+			v := kc.b.PanicHandler(kc.l)
+			if v != nil {
+				errC = errors.Join(errC, v)
+			}
+		}
+	}()
 
 	if !kc.b.IsSelfManaged(kc.p) {
 		err := kc.l.NewError(kc.ctx, "this feature is only for selfmanaged clusters")

--- a/pkg/provider/handler/selfmanagedcluster.go
+++ b/pkg/provider/handler/selfmanagedcluster.go
@@ -167,6 +167,7 @@ func (kc *Controller) AddWorkerNodes() (*provider.CloudResourceState, int, error
 	if err != nil {
 		return nil, -1, err
 	}
+
 	wg := &sync.WaitGroup{}
 
 	errChanWP := make(chan error, kc.p.Metadata.NoWP-currWP)


### PR DESCRIPTION
## 🗒️ Changelog
<!-- Provide a clear and concise overview of the changes -->
- Patch when the panic happens the PanicHandler returns error which is then consumed by the controller as a defer func
- `ErrPanic` is added to `pkg/errors`

## 🏋🏼 Issues

### ✅ Completed Issues
<!-- List the issues this PR completes -->
- Fixes: #509
- Fixes: #511


## 🚀 Task List
<!-- List any sub-tasks or milestones -->
- [x] Added New KsctlError type for panics
- [x] Checking if anymore PanicHandlers are required or we missed something
- [x] Why is Scaleup and scaledown not working


## 🔍 Review Checklist
<!-- Mark the items you've completed -->
- [x] Code follows project style guidelines
- [ ] ~Added/updated tests~
- [x] Ran tests locally
- [ ] ~Updated documentation~
- [x] Checked [Contribution Guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)

## 📸 Screenshots/Recordings
<!-- If applicable, add screenshots or recordings -->

## 📌 Additional Notes
<!-- Any additional information for reviewers -->

---

<details>
<summary>💡 PR best practices</summary>

* Keep changes focused and atomic
* Update tests and documentation
* Check for conflicts with main branch
* Respond promptly to review comments
* Follow project coding standards
* Make sure you are using `pre-commit` for that run this command `$ pre-commit install`

</details>
