### PR TITLE
feat: added r5 series instances in aws meta vm list

### DIFF
--- a/pkg/provider/aws/meta/details.go
+++ b/pkg/provider/aws/meta/details.go
@@ -29,7 +29,7 @@ import (
 
 func WithDefaultEC2() Option {
 	return func(o *options) error {
-		o.ec2Type = []string{"c5*", "t3*", "m5*"}
+		o.ec2Type = []string{"c5*", "t3*", "m5*", "r5*"}
 		return nil
 	}
 }
@@ -103,6 +103,8 @@ func (m *AwsMeta) listOfVms(region string, opts ...Option) (out []provider.Insta
 		} else if strings.HasPrefix(vmTypeSku, "t3") {
 			category = provider.GeneralPurpose
 		} else if strings.HasPrefix(vmTypeSku, "m5") {
+			category = provider.GeneralPurpose
+		} else if strings.HasPrefix(vmTypeSku, "r5") {
 			category = provider.MemoryIntensive
 		} else {
 			return provider.Unknown
@@ -181,7 +183,7 @@ func (m *AwsMeta) listManagedOfferingsK8sVersions(regionSku string) ([]string, e
 	return s, nil
 }
 
-func (m *AwsMeta) listManagedOfferingsCNIPlugins(region string) (addons.ClusterAddons, string, error) {
+func (m *AwsMeta) listManagedOfferingsCNIPlugins(_ string) (addons.ClusterAddons, string, error) {
 	v, d := awsPkg.GetManagedCNIAddons()
 	return v, d, nil
 }


### PR DESCRIPTION
## 🗒️ Changelog
<!-- Provide a clear and concise overview of the changes -->
- adds `R5*` series in aws instance for memory intensive workloads
- fixes the instance category for t3 and m5 series

## 🏋🏼 Issues

### ✅ Completed Issues
<!-- List the issues this PR completes -->
- Fixes: #545

### 📎 Related Issues
<!-- List any related issues that might be affected by this PR -->
- Related to:


## 🚀 Task List
<!-- List any sub-tasks or milestones -->
- [ ]
- [ ]


## 🔍 Review Checklist
<!-- Mark the items you've completed -->
- [ ] Code follows project style guidelines
- [ ] Added/updated tests
- [ ] Ran tests locally
- [ ] Updated documentation
- [ ] Checked [Contribution Guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)

## 📸 Screenshots/Recordings
<!-- If applicable, add screenshots or recordings -->

## 📌 Additional Notes
<!-- Any additional information for reviewers -->

---

<details>
<summary>💡 PR best practices</summary>

* Keep changes focused and atomic
* Update tests and documentation
* Check for conflicts with main branch
* Respond promptly to review comments
* Follow project coding standards
* Make sure you are using `pre-commit` for that run this command `$ pre-commit install`

</details>
