### PR TITLE
fix: total calculation for managed cluster recommendation sys

### DIFF
--- a/pkg/handler/cluster/metadata/metadata.go
+++ b/pkg/handler/cluster/metadata/metadata.go
@@ -545,6 +545,7 @@ func (kc *Controller) CostOptimizeAcrossRegions(
 			kc.findInstanceCostAcrossRegions,
 		)
 		resC, err := o.InstanceTypeOptimizerAcrossRegions(
+			regionMap,
 			consts.ClusterTypeMang,
 			nil, _o,
 			currentRegion,
@@ -565,6 +566,7 @@ func (kc *Controller) CostOptimizeAcrossRegions(
 	)
 
 	resC, err := o.InstanceTypeOptimizerAcrossRegions(
+		regionMap,
 		consts.ClusterTypeMang,
 		_o, nil,
 		currentRegion,

--- a/pkg/provider/optimizer/costs.go
+++ b/pkg/provider/optimizer/costs.go
@@ -210,6 +210,7 @@ type RecommendationAcrossRegions struct {
 //
 //	TODO: also wrt to the emissions as well!!!
 func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
+	regions map[string]provider.RegionOutput,
 	clusterType consts.KsctlClusterType,
 	costsManaged []RecommendationManagedCost,
 	costsSelfManaged []RecommendationSelfManagedCost,
@@ -244,11 +245,10 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 	if clusterType == consts.ClusterTypeMang {
 		idxCurrReg := -1
 		for i, cost := range costsManaged {
-			total := cost.CpCost + cost.WpCost*float64(noOfWP)
 			if cost.Region == currRegion {
 				idxCurrReg = i
-				res.CurrentTotalCost = total
-				if v, ok := k.getRegionsInMapFormat()[cost.Region]; ok && v.Emission != nil {
+				res.CurrentTotalCost = cost.CpCost + cost.WpCost*float64(noOfWP)
+				if v, ok := regions[cost.Region]; ok && v.Emission != nil {
 					res.CurrentEmissions = v.Emission
 				}
 				break
@@ -259,7 +259,7 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 			total := cost.CpCost + cost.WpCost*float64(noOfWP)
 
 			var regionEmissions *provider.RegionalEmission
-			if v, ok := k.getRegionsInMapFormat()[cost.Region]; ok && v.Emission != nil {
+			if v, ok := regions[cost.Region]; ok && v.Emission != nil {
 				regionEmissions = v.Emission
 			}
 			res.RegionRecommendations = append(res.RegionRecommendations, RegionRecommendation{
@@ -278,7 +278,7 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 			if cost.Region == currRegion {
 				idxCurrReg = i
 				res.CurrentTotalCost = total
-				if v, ok := k.getRegionsInMapFormat()[cost.Region]; ok && v.Emission != nil {
+				if v, ok := regions[cost.Region]; ok && v.Emission != nil {
 					res.CurrentEmissions = v.Emission
 				}
 				break
@@ -289,7 +289,7 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 			total := cost.CpCost*float64(noOfCP) + cost.WpCost*float64(noOfWP) + cost.EtcdCost*float64(noOfDS) + cost.LbCost
 
 			var regionEmissions *provider.RegionalEmission
-			if v, ok := k.getRegionsInMapFormat()[cost.Region]; ok && v.Emission != nil {
+			if v, ok := regions[cost.Region]; ok && v.Emission != nil {
 				regionEmissions = v.Emission
 			}
 			res.RegionRecommendations = append(res.RegionRecommendations, RegionRecommendation{

--- a/pkg/provider/optimizer/costs.go
+++ b/pkg/provider/optimizer/costs.go
@@ -244,7 +244,7 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 	if clusterType == consts.ClusterTypeMang {
 		idxCurrReg := -1
 		for i, cost := range costsManaged {
-			total := cost.CpCost*float64(noOfCP) + cost.WpCost*float64(noOfWP)
+			total := cost.CpCost + cost.WpCost*float64(noOfWP)
 			if cost.Region == currRegion {
 				idxCurrReg = i
 				res.CurrentTotalCost = total
@@ -256,7 +256,7 @@ func (k *Optimizer) InstanceTypeOptimizerAcrossRegions(
 		}
 
 		for _, cost := range costsManaged[:idxCurrReg] {
-			total := cost.CpCost*float64(noOfCP) + cost.WpCost*float64(noOfWP)
+			total := cost.CpCost + cost.WpCost*float64(noOfWP)
 
 			var regionEmissions *provider.RegionalEmission
 			if v, ok := k.getRegionsInMapFormat()[cost.Region]; ok && v.Emission != nil {

--- a/pkg/provider/optimizer/optimizer.go
+++ b/pkg/provider/optimizer/optimizer.go
@@ -36,11 +36,3 @@ func NewOptimizer(
 		AvailRegions: availRegions,
 	}
 }
-
-func (k *Optimizer) getRegionsInMapFormat() map[string]provider.RegionOutput {
-	regionMap := make(map[string]provider.RegionOutput)
-	for _, region := range k.AvailRegions {
-		regionMap[region.Sku] = region
-	}
-	return regionMap
-}

--- a/pkg/provider/optimizer/recommendation_test.go
+++ b/pkg/provider/optimizer/recommendation_test.go
@@ -15,7 +15,6 @@
 package optimizer_test
 
 import (
-	"cmp"
 	"context"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	"github.com/ksctl/ksctl/v2/pkg/logger"
@@ -23,7 +22,6 @@ import (
 	"github.com/ksctl/ksctl/v2/pkg/provider/optimizer"
 	"gotest.tools/v3/assert"
 	"os"
-	"slices"
 	"testing"
 )
 
@@ -83,9 +81,6 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 				TotalCost: 780.0,
 			},
 		}
-		slices.SortFunc(costsSelfManaged, func(a, b optimizer.RecommendationSelfManagedCost) int {
-			return cmp.Compare(a.TotalCost, b.TotalCost)
-		})
 
 		currReg := "region1"
 
@@ -142,9 +137,6 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 				TotalCost: 780.0,
 			},
 		}
-		slices.SortFunc(costsSelfManaged, func(a, b optimizer.RecommendationSelfManagedCost) int {
-			return cmp.Compare(a.TotalCost, b.TotalCost)
-		})
 
 		currReg := "region2"
 
@@ -211,10 +203,6 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 				TotalCost: 620.0,
 			},
 		}
-
-		slices.SortFunc(costsSelfManaged, func(a, b optimizer.RecommendationSelfManagedCost) int {
-			return cmp.Compare(a.TotalCost, b.TotalCost)
-		})
 
 		currReg := "region2"
 
@@ -294,9 +282,6 @@ func TestInstanceTypeOptimizerAcrossRegionsManaged(t *testing.T) {
 				TotalCost: 400.0,
 			},
 		}
-		slices.SortFunc(costsManaged, func(a, b optimizer.RecommendationManagedCost) int {
-			return cmp.Compare(a.TotalCost, b.TotalCost)
-		})
 
 		currReg := "region1"
 
@@ -344,9 +329,6 @@ func TestInstanceTypeOptimizerAcrossRegionsManaged(t *testing.T) {
 				TotalCost: 400.0,
 			},
 		}
-		slices.SortFunc(costsManaged, func(a, b optimizer.RecommendationManagedCost) int {
-			return cmp.Compare(a.TotalCost, b.TotalCost)
-		})
 
 		currReg := "region2"
 

--- a/pkg/provider/optimizer/recommendation_test.go
+++ b/pkg/provider/optimizer/recommendation_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025 Ksctl Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimizer_test
+
+import (
+	"context"
+	"github.com/ksctl/ksctl/v2/pkg/consts"
+	"github.com/ksctl/ksctl/v2/pkg/logger"
+	"github.com/ksctl/ksctl/v2/pkg/provider"
+	"github.com/ksctl/ksctl/v2/pkg/provider/optimizer"
+	"gotest.tools/v3/assert"
+	"os"
+	"testing"
+)
+
+var (
+	ctx = context.TODO()
+	l   = logger.NewStructuredLogger(-1, os.Stdout)
+	opt = optimizer.NewOptimizer(ctx, l, nil)
+)
+
+func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
+	clusterType := consts.ClusterTypeSelfMang
+
+	regions := map[string]provider.RegionOutput{
+		"region1": {
+			Sku:  "region1",
+			Name: "region1",
+			Emission: &provider.RegionalEmission{
+				DirectCarbonIntensity: 50.0,
+				Unit:                  "gCO2/kWh",
+			},
+		},
+		"region2": {
+			Sku:  "region2",
+			Name: "region2",
+			Emission: &provider.RegionalEmission{
+				DirectCarbonIntensity: 100.0,
+				Unit:                  "gCO2/kWh",
+			},
+		},
+	}
+	cpSku := "cpSku"
+	wpSku := "wpSku"
+	lbSku := "lbSku"
+	etcdSku := "etcdSku"
+
+	// we need to validate the no in the function
+	noCP := 3
+	noWP := 4
+	noDS := 5
+
+	t.Run("2 regions have diff costs no recommendation", func(t *testing.T) {
+		costsSelfManaged := []optimizer.RecommendationSelfManagedCost{
+			{
+				Region:    "region1",
+				CpCost:    100.0,
+				WpCost:    200.0,
+				EtcdCost:  300.0,
+				LbCost:    20.0,
+				TotalCost: 620.0,
+			},
+			{
+				Region:    "region2",
+				CpCost:    150.0,
+				WpCost:    250.0,
+				EtcdCost:  350.0,
+				LbCost:    30.0,
+				TotalCost: 780.0,
+			},
+		}
+
+		currReg := "region1"
+
+		expectedResp := optimizer.RecommendationAcrossRegions{
+			CurrentRegion:         currReg,
+			CurrentEmissions:      regions[currReg].Emission,
+			CurrentTotalCost:      300.0 + 800.0 + 1500.0 + 20.0,
+			InstanceTypeCP:        cpSku,
+			InstanceTypeWP:        wpSku,
+			InstanceTypeDS:        etcdSku,
+			InstanceTypeLB:        lbSku,
+			ControlPlaneCount:     noCP,
+			WorkerPlaneCount:      noWP,
+			DataStoreCount:        noDS,
+			RegionRecommendations: nil,
+		}
+
+		actualResp, err := opt.InstanceTypeOptimizerAcrossRegions(
+			regions,
+			clusterType,
+			nil,
+			costsSelfManaged,
+			currReg,
+			noCP,
+			noWP,
+			noDS,
+			"",
+			cpSku,
+			wpSku,
+			etcdSku,
+			lbSku,
+		)
+
+		assert.NilError(t, err, "error should be nil")
+		assert.DeepEqual(t, expectedResp, actualResp)
+	})
+}
+
+func TestInstanceTypeOptimizerAcrossRegionsManaged(t *testing.T) {
+	clusterType := consts.ClusterTypeMang
+
+	regions := map[string]provider.RegionOutput{
+		"region1": {
+			Sku:  "region1",
+			Name: "region1",
+			Emission: &provider.RegionalEmission{
+				DirectCarbonIntensity: 50.0,
+				Unit:                  "gCO2/kWh",
+			},
+		},
+		"region2": {
+			Sku:  "region2",
+			Name: "region2",
+			Emission: &provider.RegionalEmission{
+				DirectCarbonIntensity: 100.0,
+				Unit:                  "gCO2/kWh",
+			},
+		},
+	}
+	managedOfferSku := "managedOfferSku"
+	wpSku := "wpSku"
+
+	// we need to validate the no in the function
+	noWP := 4
+	noCP := 0
+	noDS := 0
+
+	t.Run("2 regions have diff costs no recommendation", func(t *testing.T) {
+		costsManaged := []optimizer.RecommendationManagedCost{
+			{
+				Region:    "region1",
+				CpCost:    100.0,
+				WpCost:    200.0,
+				TotalCost: 300.0,
+			},
+			{
+				Region:    "region2",
+				CpCost:    150.0,
+				WpCost:    250.0,
+				TotalCost: 400.0,
+			},
+		}
+
+		currReg := "region1"
+
+		expectedResp := optimizer.RecommendationAcrossRegions{
+			CurrentRegion:         currReg,
+			CurrentEmissions:      regions[currReg].Emission,
+			CurrentTotalCost:      100.0 + 800.0,
+			ManagedOffering:       managedOfferSku,
+			InstanceTypeWP:        wpSku,
+			WorkerPlaneCount:      noWP,
+			RegionRecommendations: nil,
+		}
+
+		actualResp, err := opt.InstanceTypeOptimizerAcrossRegions(
+			regions,
+			clusterType,
+			costsManaged,
+			nil,
+			currReg,
+			noCP,
+			noWP,
+			noDS,
+			managedOfferSku,
+			"",
+			wpSku,
+			"", "",
+		)
+
+		assert.NilError(t, err, "error should be nil")
+		assert.DeepEqual(t, expectedResp, actualResp)
+	})
+}

--- a/pkg/provider/optimizer/recommendation_test.go
+++ b/pkg/provider/optimizer/recommendation_test.go
@@ -193,7 +193,6 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 	})
 
 	t.Run("2 regions have same costs no recommendation", func(t *testing.T) {
-		// CAUTION: if the region2 is above region 1 then testcases passes, but if below then it fails aka generates recommendation
 		costsSelfManaged := []optimizer.RecommendationSelfManagedCost{
 			{
 				Region:    "region1",

--- a/pkg/provider/optimizer/recommendation_test.go
+++ b/pkg/provider/optimizer/recommendation_test.go
@@ -40,6 +40,8 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 			Name: "region1",
 			Emission: &provider.RegionalEmission{
 				DirectCarbonIntensity: 50.0,
+				RenewablePercentage:   74.4,
+				LowCarbonPercentage:   5.5,
 				Unit:                  "gCO2/kWh",
 			},
 		},
@@ -48,6 +50,8 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 			Name: "region2",
 			Emission: &provider.RegionalEmission{
 				DirectCarbonIntensity: 100.0,
+				RenewablePercentage:   94.4,
+				LowCarbonPercentage:   9.5,
 				Unit:                  "gCO2/kWh",
 			},
 		},
@@ -207,17 +211,27 @@ func TestInstanceTypeOptimizerAcrossRegionsSelfManaged(t *testing.T) {
 		currReg := "region2"
 
 		expectedResp := optimizer.RecommendationAcrossRegions{
-			CurrentRegion:         currReg,
-			CurrentEmissions:      regions[currReg].Emission,
-			CurrentTotalCost:      100.0*float64(noCP) + 200.0*float64(noWP) + 300.0*float64(noDS) + 20.0,
-			InstanceTypeCP:        cpSku,
-			InstanceTypeWP:        wpSku,
-			InstanceTypeDS:        etcdSku,
-			InstanceTypeLB:        lbSku,
-			ControlPlaneCount:     noCP,
-			WorkerPlaneCount:      noWP,
-			DataStoreCount:        noDS,
-			RegionRecommendations: nil,
+			CurrentRegion:     currReg,
+			CurrentEmissions:  regions[currReg].Emission,
+			CurrentTotalCost:  100.0*float64(noCP) + 200.0*float64(noWP) + 300.0*float64(noDS) + 20.0,
+			InstanceTypeCP:    cpSku,
+			InstanceTypeWP:    wpSku,
+			InstanceTypeDS:    etcdSku,
+			InstanceTypeLB:    lbSku,
+			ControlPlaneCount: noCP,
+			WorkerPlaneCount:  noWP,
+			DataStoreCount:    noDS,
+			RegionRecommendations: []optimizer.RegionRecommendation{
+				{
+					Region:           "region1",
+					ControlPlaneCost: 100.0,
+					WorkerPlaneCost:  200.0,
+					DataStoreCost:    300.0,
+					LoadBalancerCost: 20.0,
+					TotalCost:        100.0*float64(noCP) + 200.0*float64(noWP) + 300.0*float64(noDS) + 20.0,
+					Emissions:        regions["region1"].Emission,
+				},
+			},
 		}
 
 		actualResp, err := opt.InstanceTypeOptimizerAcrossRegions(


### PR DESCRIPTION
## 🗒️ Changelog
<!-- Provide a clear and concise overview of the changes -->
This pull request includes changes to the `InstanceTypeOptimizerAcrossRegions` function in the `pkg/provider/optimizer/costs.go` file to correct the calculation of total costs. The most important changes include removing the multiplication of `CpCost` by `noOfCP` in two locations.

Corrections to cost calculations:

* [`pkg/provider/optimizer/costs.go`](diffhunk://#diff-558f54f19f4bde9d494d8d17050cf149ca39c795aa3fd38fb388221033a527f6L247-R247): Corrected the calculation of `total` by removing the multiplication of `CpCost` by `noOfCP` in the first loop.
* [`pkg/provider/optimizer/costs.go`](diffhunk://#diff-558f54f19f4bde9d494d8d17050cf149ca39c795aa3fd38fb388221033a527f6L259-R259): Corrected the calculation of `total` by removing the multiplication of `CpCost` by `noOfCP` in the second loop.

## 🏋🏼 Issues

### ✅ Completed Issues
<!-- List the issues this PR completes -->
- Fixes: #556

## 🚀 Task List
<!-- List any sub-tasks or milestones -->
- [ ]
- [ ]


## 🔍 Review Checklist
<!-- Mark the items you've completed -->
- [ ] Code follows project style guidelines
- [ ] Added/updated tests
- [ ] Ran tests locally
- [ ] Updated documentation
- [ ] Checked [Contribution Guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)

## 📸 Screenshots/Recordings
<!-- If applicable, add screenshots or recordings -->

## 📌 Additional Notes
<!-- Any additional information for reviewers -->

---

<details>
<summary>💡 PR best practices</summary>

* Keep changes focused and atomic
* Update tests and documentation
* Check for conflicts with main branch
* Respond promptly to review comments
* Follow project coding standards
* Make sure you are using `pre-commit` for that run this command `$ pre-commit install`

</details>
