### PR TITLE
fix: the bug in prefix for poller

### DIFF
--- a/pkg/poller/github_releases.go
+++ b/pkg/poller/github_releases.go
@@ -102,7 +102,7 @@ func (gh *GithubReleasePoller) getSubscribedRepos() []string {
 	}
 
 	for _, k := range keys {
-		repos = append(repos, k)
+		repos = append(repos, strings.TrimPrefix(k, prefix_cache))
 	}
 
 	return repos

--- a/pkg/poller/github_releases_test.go
+++ b/pkg/poller/github_releases_test.go
@@ -106,7 +106,7 @@ func TestGetSubscribedRepos(t *testing.T) {
 	if len(repos) != 1 {
 		t.Errorf("Expected 1, got %d", len(repos))
 	} else {
-		if repos[0] != prefix_cache+"org/repo" {
+		if repos[0] != "org/repo" {
 			t.Errorf("Expected org/repo, got %s", repos[0])
 		}
 	}


### PR DESCRIPTION
5) "poller:etcd-io/etcd"
11) "poller:poller:etcd-io/etcd"

Signed-off-by: Dipankar Das <65275144+dipankardas011@users.noreply.github.com>

## 🗒️ Changelog
<!-- Provide a clear and concise overview of the changes -->


## 🏋🏼 Issues

### ✅ Completed Issues
<!-- List the issues this PR completes -->
- Fixes:

### 📎 Related Issues
<!-- List any related issues that might be affected by this PR -->
- Related to:


## 🚀 Task List
<!-- List any sub-tasks or milestones -->
- [ ]
- [ ]


## 🔍 Review Checklist
<!-- Mark the items you've completed -->
- [ ] Code follows project style guidelines
- [ ] Added/updated tests
- [ ] Ran tests locally
- [ ] Updated documentation
- [ ] Checked [Contribution Guidelines](https://docs.ksctl.com/docs/contribution-guidelines/)

## 📸 Screenshots/Recordings
<!-- If applicable, add screenshots or recordings -->

## 📌 Additional Notes
<!-- Any additional information for reviewers -->

---

<details>
<summary>💡 PR best practices</summary>

* Keep changes focused and atomic
* Update tests and documentation
* Check for conflicts with main branch
* Respond promptly to review comments
* Follow project coding standards
* Make sure you are using `pre-commit` for that run this command `$ pre-commit install`

</details>
